### PR TITLE
Be gentle

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(name='pipelinewise-tap-postgres',
       ],
       install_requires=[
           'singer-python==5.3.1',
-          'psycopg2==2.8.3',
+          'psycopg2==2.8.2',
           'strict-rfc3339==0.7',
           'nose==1.3.7'
       ],

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
       long_description = f.read()
 
 setup(name='pipelinewise-tap-postgres',
-      version='1.1.1',
+      version='1.1.2',
       description='Singer.io tap for extracting data from PostgreSQL - PipelineWise compatible',
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -27,6 +27,11 @@ def get_pg_version(cur):
     LOGGER.debug("Detected PostgreSQL version: %s", version)
     return version
 
+def lsn_to_int(f_lsn):
+    """Convert pg_lsn format to int"""
+    file, index = f_lsn.split('/')
+    return (int(file, 16)  << 32) + int(index, 16)
+
 def fetch_current_lsn(conn_config):
     with post_db.open_connection(conn_config, False) as conn:
         with conn.cursor() as cur:
@@ -56,8 +61,7 @@ def fetch_current_lsn(conn_config):
                 raise Exception('Logical replication not supported before PostgreSQL 9.4')
 
             current_lsn = cur.fetchone()[0]
-            file, index = current_lsn.split('/')
-            return (int(file, 16)  << 32) + int(index, 16)
+            return lsn_to_int(current_lsn)
 
 def add_automatic_properties(stream, conn_config):
     stream['schema']['properties']['_sdc_deleted_at'] = {'type' : ['null', 'string'], 'format' :'date-time'}

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -31,6 +31,22 @@ def lsn_to_int(f_lsn):
     file, index = f_lsn.split('/')
     return (int(file, 16)  << 32) + int(index, 16)
 
+def int_to_lsn(lsni):
+    """Convert int to pg_lsn"""
+
+    # Convert the integer to binary
+    lsnb = '{0:b}'.format(lsni)
+
+    # file is the binary before the 32nd character, converted to hex
+    file = (format(int(lsnb[:-32], 2), 'x')).upper()
+
+    # index is the binary from the 32nd character, converted to hex
+    index = (format(int(lsnb[-32:], 2), 'x')).upper()
+
+    # Formatting
+    lsn = "{}/{}".format(file, index)
+    return(lsn)
+
 def fetch_current_lsn(conn_config):
     with post_db.open_connection(conn_config, False) as conn:
         with conn.cursor() as cur:

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -346,7 +346,7 @@ def sync_tables(conn_info, logical_streams, state, end_lsn):
         with conn.cursor() as cur:
             LOGGER.info("Starting Logical Replication for %s(%s): %s -> %s. logical_poll_total_seconds: %s", list(map(lambda s: s['tap_stream_id'], logical_streams)), slot, start_lsn, end_lsn, logical_poll_total_seconds)
             try:
-                cur.start_replication(slot_name=slot, decode=True, start_lsn=start_lsn, status_interval=poll_interval, options={'write-in-chunks': 1})
+                cur.start_replication(slot_name=slot, decode=True, start_lsn=start_lsn, options={'write-in-chunks': 1})
             except psycopg2.ProgrammingError:
                 raise Exception("unable to start replication with logical replication slot {}".format(slot))
 

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -26,10 +26,11 @@ def get_pg_version(cur):
     LOGGER.debug("Detected PostgreSQL version: %s", version)
     return version
 
-def lsn_to_int(f_lsn):
+def lsn_to_int(lsn):
     """Convert pg_lsn to int"""
-    file, index = f_lsn.split('/')
-    return (int(file, 16)  << 32) + int(index, 16)
+    file, index = lsn.split('/')
+    lnsi = (int(file, 16)  << 32) + int(index, 16)
+    return(lsni)
 
 def int_to_lsn(lsni):
     """Convert int to pg_lsn"""

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -381,7 +381,7 @@ def sync_tables(conn_info, logical_streams, state, end_lsn):
 
                 # When data is received, and when data is not received, a keep-alive poll needs to be returned to PostgreSQL
                 if datetime.datetime.now() >= (poll_timestamp + datetime.timedelta(seconds=poll_interval)):
-                    LOGGER.info("{} : Sending keep-alive to source server - waiting for wal entries".format(datetime.datetime.utcnow()))
+                    LOGGER.info("{} : Sending keep-alive to source server".format(datetime.datetime.utcnow()))
                     cur.send_feedback()
                     poll_timestamp = datetime.datetime.now()
 

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -408,13 +408,13 @@ def sync_tables(conn_info, logical_streams, state, end_lsn):
 
                 # When data is received, and when data is not received, a keep-alive poll needs to be returned to PostgreSQL
                 if datetime.datetime.utcnow() >= (poll_timestamp + datetime.timedelta(seconds=poll_interval)):
-                    LOGGER.info("{} : Sending keep-alive to source server ({} wal message received at {})".format(datetime.datetime.utcnow(), int_to_lsn(lsn_last_processed), lsn_received_timestamp))
+                    LOGGER.info("{} : Sending keep-alive to source server (last message received was {} at {})".format(datetime.datetime.utcnow(), int_to_lsn(lsn_last_processed), lsn_received_timestamp))
                     cur.send_feedback()
                     poll_timestamp = datetime.datetime.utcnow()
 
     if lsn_last_processed:
         for s in logical_streams:
-            LOGGER.info("updating bookmark for stream %s to lsn_last_processed %s", s['tap_stream_id'], int_to_lsn(lsn_last_processed))
+            LOGGER.info("updating bookmark for stream {} to lsn={} ({})".format(s['tap_stream_id'], lsn_last_processed, int_to_lsn(lsn_last_processed)))
             state = singer.write_bookmark(state, s['tap_stream_id'], 'lsn', lsn_last_processed)
 
     singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -414,7 +414,7 @@ def sync_tables(conn_info, logical_streams, state, end_lsn):
 
     if lsn_last_processed:
         for s in logical_streams:
-            LOGGER.info("updating bookmark for stream %s to lsn_last_processed %s", s['tap_stream_id'], lsn_last_processed)
+            LOGGER.info("updating bookmark for stream %s to lsn_last_processed %s", s['tap_stream_id'], int_to_lsn(lsn_last_processed))
             state = singer.write_bookmark(state, s['tap_stream_id'], 'lsn', lsn_last_processed)
 
     singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -380,7 +380,7 @@ def sync_tables(conn_info, logical_streams, state, end_lsn):
                 raise Exception("unable to start replication with logical replication slot {}".format(slot))
 
             # Flush Postgres log up to lsn saved in state file from previous run
-            LOGGER.info("Sending flush_lsn = {} ({}) to source server".format(comitted_lsn, int_to_lsn(comitted_lsn)))
+            LOGGER.info("{} : Sending flush_lsn = {} ({}) to source server".format(datetime.datetime.utcnow(), comitted_lsn, int_to_lsn(comitted_lsn)))
             cur.send_feedback(flush_lsn=comitted_lsn, reply=True)
 
             while True:

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -36,16 +36,14 @@ def int_to_lsn(lsni):
 
     # Convert the integer to binary
     lsnb = '{0:b}'.format(lsni)
-
     # file is the binary before the 32nd character, converted to hex
     file = (format(int(lsnb[:-32], 2), 'x')).upper()
-
     # index is the binary from the 32nd character, converted to hex
     index = (format(int(lsnb[-32:], 2), 'x')).upper()
-
     # Formatting
     lsn = "{}/{}".format(file, index)
     return(lsn)
+
 
 def fetch_current_lsn(conn_config):
     with post_db.open_connection(conn_config, False) as conn:

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -28,7 +28,7 @@ def get_pg_version(cur):
     return version
 
 def lsn_to_int(f_lsn):
-    """Convert pg_lsn format to int"""
+    """Convert pg_lsn to int"""
     file, index = f_lsn.split('/')
     return (int(file, 16)  << 32) + int(index, 16)
 

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -3,6 +3,7 @@
 
 import singer
 import datetime
+import time
 import decimal
 from singer import utils, get_bookmark
 import singer.metadata as metadata
@@ -346,7 +347,10 @@ def sync_tables(conn_info, logical_streams, state, end_lsn):
 
             # Flush Postgres log up to lsn saved in state file from previous run
             LOGGER.info("Sending flush_lsn = {} to source server".format(comitted_lsn))
-            cur.send_feedback(flush_lsn=comitted_lsn)
+            cur.send_feedback(flush_lsn=comitted_lsn, reply=True, force=True)
+            # Give source server a rest
+            time.sleep(poll_interval)
+
 
             while True:
                 # Disconnect when no data received for logical_poll_total_seconds

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -26,19 +26,26 @@ def get_pg_version(cur):
     LOGGER.debug("Detected PostgreSQL version: %s", version)
     return version
 
+
 def lsn_to_int(lsn):
     """Convert pg_lsn to int"""
     file, index = lsn.split('/')
     lsni = (int(file, 16)  << 32) + int(index, 16)
     return(lsni)
 
+
 def int_to_lsn(lsni):
     """Convert int to pg_lsn"""
 
     # Convert the integer to binary
     lsnb = '{0:b}'.format(lsni)
+
     # file is the binary before the 32nd character, converted to hex
-    file = (format(int(lsnb[:-32], 2), 'x')).upper()
+    if len(lsnb) > 32:
+        file = (format(int(lsnb[:-32], 2), 'x')).upper()
+    else:
+        file = '0'
+
     # index is the binary from the 32nd character, converted to hex
     index = (format(int(lsnb[-32:], 2), 'x')).upper()
     # Formatting

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -381,7 +381,7 @@ def sync_tables(conn_info, logical_streams, state, end_lsn):
 
                 # When data is received, and when data is not received, a keep-alive poll needs to be returned to PostgreSQL
                 if datetime.datetime.now() >= (poll_timestamp + datetime.timedelta(seconds=poll_interval)):
-                    LOGGER.info("{} : Sending keep-alive to source server - currently waiting for wal entries".format(datetime.datetime.utcnow()))
+                    LOGGER.info("{} : Sending keep-alive to source server - waiting for wal entries".format(datetime.datetime.utcnow()))
                     cur.send_feedback()
                     poll_timestamp = datetime.datetime.now()
 

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -352,9 +352,9 @@ def sync_tables(conn_info, logical_streams, state, end_lsn):
 
             # Flush Postgres log up to lsn saved in state file from previous run
             LOGGER.info("Sending flush_lsn = {} to source server".format(comitted_lsn))
-            cur.send_feedback(flush_lsn=comitted_lsn, reply=True, force=True)
-            # Give source server a rest
-            time.sleep(poll_interval)
+            cur.send_feedback(flush_lsn=comitted_lsn, reply=True)
+            # Give source server a short rest
+            time.sleep(1)
 
 
             while True:

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -362,7 +362,7 @@ def sync_tables(conn_info, logical_streams, state, end_lsn):
     slot = locate_replication_slot(conn_info)
     lsn_last_processed = None
     lsn_currently_processing = None
-    lsn_received_timestamp = None
+    lsn_received_timestamp = datetime.datetime.utcnow()
     lsn_processed = 0
     logical_poll_total_seconds = conn_info['logical_poll_total_seconds'] or 600
     poll_interval = 10
@@ -386,11 +386,10 @@ def sync_tables(conn_info, logical_streams, state, end_lsn):
             while True:
                 # Disconnect when no data received for logical_poll_total_seconds
                 # needs to be long enough to wait for the largest single wal payload to avoid unplanned timeouts
-                if lsn_received_timestamp:
-                    poll_duration = (datetime.datetime.utcnow() - lsn_received_timestamp).total_seconds()
-                    if poll_duration > logical_poll_total_seconds:
-                        LOGGER.info("Breaking after %s seconds of polling with no data", poll_duration)
-                        break
+                poll_duration = (datetime.datetime.utcnow() - lsn_received_timestamp).total_seconds()
+                if poll_duration > logical_poll_total_seconds:
+                    LOGGER.info("Breaking after %s seconds of polling with no data", poll_duration)
+                    break
 
                 msg = cur.read_message()
                 if msg:

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -364,7 +364,7 @@ def sync_tables(conn_info, logical_streams, state, end_lsn):
     lsn_currently_processing = None
     lsn_received_timestamp = datetime.datetime.utcnow()
     lsn_processed = 0
-    logical_poll_total_seconds = conn_info['logical_poll_total_seconds'] or 600
+    logical_poll_total_seconds = conn_info['logical_poll_total_seconds'] or 300
     poll_interval = 10
     poll_timestamp = datetime.datetime.utcnow()
 
@@ -394,7 +394,7 @@ def sync_tables(conn_info, logical_streams, state, end_lsn):
                 msg = cur.read_message()
                 if msg:
                     if msg.data_start > end_lsn:
-                        LOGGER.info("Gone past end_lsn %s for run. breaking", int_to_lsn(end_lsn))
+                        LOGGER.info("{} : Current {} is past end_lsn {} - breaking".format(datetime.datetime.utcnow(), int_to_lsn(msg.data_start), int_to_lsn(end_lsn)))
                         break
 
                     state = consume_message(logical_streams, state, msg, time_extracted, conn_info, end_lsn)

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -29,7 +29,7 @@ def get_pg_version(cur):
 def lsn_to_int(lsn):
     """Convert pg_lsn to int"""
     file, index = lsn.split('/')
-    lnsi = (int(file, 16)  << 32) + int(index, 16)
+    lsni = (int(file, 16)  << 32) + int(index, 16)
     return(lsni)
 
 def int_to_lsn(lsni):


### PR DESCRIPTION
- Safeguard against flushing half processed wal entries
- Change logging to use pg_lsn format
- Change internal timestamps to UTC