### PR TITLE
Update singer streams to lsn_last_processed before emiting STATE message

### DIFF
--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -434,10 +434,9 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
                 lsn_received_timestamp = datetime.datetime.utcnow()
                 lsn_processed_count = lsn_processed_count + 1
                 if lsn_processed_count >= UPDATE_BOOKMARK_PERIOD:
-                    LOGGER.info("Updating bookmarks for all streams to lsn = {} ({})".format(lsn_last_processed, int_to_lsn(lsn_last_processed)))
+                    # Updating bookmarks for all streams to lsn = lsn_last_processed
                     for s in logical_streams:
                         state = singer.write_bookmark(state, s['tap_stream_id'], 'lsn', lsn_last_processed)
-
                     singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
                     lsn_processed_count = 0
 

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -434,7 +434,7 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
                 lsn_received_timestamp = datetime.datetime.utcnow()
                 lsn_processed_count = lsn_processed_count + 1
                 if lsn_processed_count >= UPDATE_BOOKMARK_PERIOD:
-                    # Updating bookmarks for all streams to lsn = lsn_last_processed
+                    LOGGER.info("{} : Updating bookmarks for all streams to lsn = {} ({})".format(datetime.datetime.utcnow(), lsn_last_processed, int_to_lsn(lsn_last_processed)))
                     for s in logical_streams:
                         state = singer.write_bookmark(state, s['tap_stream_id'], 'lsn', lsn_last_processed)
                     singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
@@ -469,7 +469,7 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
             lsn_last_processed = lsn_comitted
             LOGGER.info("Current lsn_last_processed {} is older than lsn_comitted {}".format(int_to_lsn(lsn_last_processed), int_to_lsn(lsn_comitted)))
 
-        LOGGER.info("Updating bookmarks for all streams to lsn = {} ({})".format(lsn_last_processed, int_to_lsn(lsn_last_processed)))
+        LOGGER.info("{} : Updating bookmarks for all streams to lsn = {} ({})".format(datetime.datetime.utcnow(), lsn_last_processed, int_to_lsn(lsn_last_processed)))
         for s in logical_streams:
             state = singer.write_bookmark(state, s['tap_stream_id'], 'lsn', lsn_last_processed)
 

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -434,6 +434,10 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
                 lsn_received_timestamp = datetime.datetime.utcnow()
                 lsn_processed_count = lsn_processed_count + 1
                 if lsn_processed_count >= UPDATE_BOOKMARK_PERIOD:
+                    LOGGER.info("Updating bookmarks for all streams to lsn = {} ({})".format(lsn_last_processed, int_to_lsn(lsn_last_processed)))
+                    for s in logical_streams:
+                        state = singer.write_bookmark(state, s['tap_stream_id'], 'lsn', lsn_last_processed)
+
                     singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
                     lsn_processed_count = 0
 
@@ -465,8 +469,9 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
         if lsn_comitted > lsn_last_processed:
             lsn_last_processed = lsn_comitted
             LOGGER.info("Current lsn_last_processed {} is older than lsn_comitted {}".format(int_to_lsn(lsn_last_processed), int_to_lsn(lsn_comitted)))
+
+        LOGGER.info("Updating bookmarks for all streams to lsn = {} ({})".format(lsn_last_processed, int_to_lsn(lsn_last_processed)))
         for s in logical_streams:
-            LOGGER.info("updating bookmark for stream {} to lsn = {} ({})".format(s['tap_stream_id'], lsn_last_processed, int_to_lsn(lsn_last_processed)))
             state = singer.write_bookmark(state, s['tap_stream_id'], 'lsn', lsn_last_processed)
 
     singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))


### PR DESCRIPTION
previous output
`
{
    "type": "STATE",
    "value": {
        "bookmarks": {
            "postgres_source_db-logical1-logical1_table1": {
                "last_replication_method": "LOG_BASED",
                "lsn": 25346960,
                "version": 1569418760524,
                "xmin": null
            },
            "postgres_source_db-logical1-logical1_table2": {
                "last_replication_method": "LOG_BASED",
                "lsn": 25347344,
                "version": 1569418760548,
                "xmin": null
            },
            "postgres_source_db-logical2-logical2_table1": {
                "last_replication_method": "LOG_BASED",
                "lsn": 1,
                "version": 1569418760563,
                "xmin": null
            }
        },
        "currently_syncing": null
    }
}
`
new output
`
{
    "type": "STATE",
    "value": {
        "bookmarks": {
            "postgres_source_db-logical1-logical1_table1": {
                "last_replication_method": "LOG_BASED",
                "lsn": 25347344,
                "version": 1569418760524,
                "xmin": null
            },
            "postgres_source_db-logical1-logical1_table2": {
                "last_replication_method": "LOG_BASED",
                "lsn": 25347344,
                "version": 1569418760548,
                "xmin": null
            },
            "postgres_source_db-logical2-logical2_table1": {
                "last_replication_method": "LOG_BASED",
                "lsn": 25347344,
                "version": 1569418760563,
                "xmin": null
            }
        },
        "currently_syncing": null
    }
}
`