### PR TITLE
make break_at_end_lsn optional

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
       long_description = f.read()
 
 setup(name='pipelinewise-tap-postgres',
-      version='1.2.1',
+      version='1.3.0',
       description='Singer.io tap for extracting data from PostgreSQL - PipelineWise compatible',
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -770,6 +770,7 @@ def main_impl():
                    'filter_schemas' : args.config.get('filter_schemas'),
                    'debug_lsn' : args.config.get('debug_lsn') == 'true',
                    'break_at_current_lsn' : args.config.get('break_at_current_lsn', True),
+                   'maximum_run_seconds' : args.config.get('maximum_run_seconds', 43200)
                    'logical_poll_total_seconds': float(args.config.get('logical_poll_total_seconds', 0))
                    }
 

--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -769,8 +769,8 @@ def main_impl():
                    'filter_dbs' : args.config.get('filter_dbs'),
                    'filter_schemas' : args.config.get('filter_schemas'),
                    'debug_lsn' : args.config.get('debug_lsn') == 'true',
-                   'break_at_current_lsn' : args.config.get('break_at_current_lsn', True),
                    'max_run_seconds' : args.config.get('max_run_seconds', 43200),
+                   'break_at_current_lsn' : args.config.get('break_at_current_lsn', True),
                    'logical_poll_total_seconds': float(args.config.get('logical_poll_total_seconds', 0))
                    }
 

--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -770,7 +770,7 @@ def main_impl():
                    'filter_schemas' : args.config.get('filter_schemas'),
                    'debug_lsn' : args.config.get('debug_lsn') == 'true',
                    'break_at_current_lsn' : args.config.get('break_at_current_lsn', True),
-                   'maximum_run_seconds' : args.config.get('maximum_run_seconds', 43200),
+                   'max_run_seconds' : args.config.get('max_run_seconds', 43200),
                    'logical_poll_total_seconds': float(args.config.get('logical_poll_total_seconds', 0))
                    }
 

--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -770,7 +770,7 @@ def main_impl():
                    'filter_schemas' : args.config.get('filter_schemas'),
                    'debug_lsn' : args.config.get('debug_lsn') == 'true',
                    'break_at_current_lsn' : args.config.get('break_at_current_lsn', True),
-                   'maximum_run_seconds' : args.config.get('maximum_run_seconds', 43200)
+                   'maximum_run_seconds' : args.config.get('maximum_run_seconds', 43200),
                    'logical_poll_total_seconds': float(args.config.get('logical_poll_total_seconds', 0))
                    }
 

--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -770,7 +770,7 @@ def main_impl():
                    'filter_schemas' : args.config.get('filter_schemas'),
                    'debug_lsn' : args.config.get('debug_lsn') == 'true',
                    'max_run_seconds' : args.config.get('max_run_seconds', 43200),
-                   'break_at_current_lsn' : args.config.get('break_at_current_lsn', True),
+                   'break_at_end_lsn' : args.config.get('break_at_end_lsn', True),
                    'logical_poll_total_seconds': float(args.config.get('logical_poll_total_seconds', 0))
                    }
 

--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -769,6 +769,7 @@ def main_impl():
                    'filter_dbs' : args.config.get('filter_dbs'),
                    'filter_schemas' : args.config.get('filter_schemas'),
                    'debug_lsn' : args.config.get('debug_lsn') == 'true',
+                   'break_at_current_lsn' : args.config.get('break_at_current_lsn', True),
                    'logical_poll_total_seconds': float(args.config.get('logical_poll_total_seconds', 0))
                    }
 

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -445,13 +445,13 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
             # This is to ensure we only flush to lsn that has completed entirely
             if lsn_currently_processing is None:
                 lsn_currently_processing = msg.data_start
-                LOGGER.info("{} : First wal message received was {} at {}".format(datetime.datetime.utcnow(), int_to_lsn(lsn_currently_processing), datetime.datetime.utcnow()))
+                LOGGER.info("{} : First wal message received is {}".format(datetime.datetime.utcnow(), int_to_lsn(lsn_currently_processing)))
 
                 # Flush Postgres wal up to lsn comitted in previous run, or first lsn received in this run
                 lsn_to_flush = lsn_comitted
                 if lsn_currently_processing < lsn_to_flush: lsn_to_flush = lsn_currently_processing
                 LOGGER.info("{} : Confirming write up to {}, flush to {}".format(datetime.datetime.utcnow(), int_to_lsn(lsn_to_flush), int_to_lsn(lsn_to_flush)))
-                cur.send_feedback(write_lsn=lsn_to_flush, flush_lsn=lsn_to_flush, reply=True)
+                cur.send_feedback(write_lsn=lsn_to_flush, flush_lsn=lsn_to_flush, reply=True, force=True)
 
             elif (int(msg.data_start) > lsn_currently_processing):
                 lsn_last_processed = lsn_currently_processing
@@ -470,7 +470,7 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
             if lsn_currently_processing is None:
                 LOGGER.info("{} : Waiting for first wal message".format(datetime.datetime.utcnow()))
             else:
-                LOGGER.info("{} : Last wal message received was {} at {}".format(datetime.datetime.utcnow(), int_to_lsn(lsn_last_processed), lsn_received_timestamp))
+                LOGGER.info("{} : Lastest wal message received is {}".format(datetime.datetime.utcnow(), int_to_lsn(lsn_last_processed)))
                 try:
                     state_comitted_file = open(state_file)
                     state_comitted = json.load(state_comitted_file)
@@ -481,7 +481,7 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
                     if (lsn_currently_processing > lsn_comitted) and (lsn_comitted > lsn_to_flush):
                         lsn_to_flush = lsn_comitted
                         LOGGER.info("{} : Confirming write up to {}, flush to {}".format(datetime.datetime.utcnow(), int_to_lsn(lsn_to_flush), int_to_lsn(lsn_to_flush)))
-                        cur.send_feedback(write_lsn=lsn_to_flush, flush_lsn=lsn_to_flush, reply=True)
+                        cur.send_feedback(write_lsn=lsn_to_flush, flush_lsn=lsn_to_flush, reply=True, force=True)
 
             poll_timestamp = datetime.datetime.utcnow()
 

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -466,7 +466,7 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
             if lsn_currently_processing is None:
                 LOGGER.info("{} : Waiting for first wal message".format(datetime.datetime.utcnow()))
             else:
-                LOGGER.info("{} : Lastest wal message received is {}".format(datetime.datetime.utcnow(), int_to_lsn(lsn_last_processed)))
+                LOGGER.info("{} : Lastest wal message received was {}".format(datetime.datetime.utcnow(), int_to_lsn(lsn_last_processed)))
                 try:
                     state_comitted_file = open(state_file)
                     state_comitted = json.load(state_comitted_file)

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -384,8 +384,8 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
     lsn_currently_processing = None
     lsn_received_timestamp = None
     lsn_processed_count = 0
-    start_run_timestamp = datetime.datetime.utcnow()
     break_at_current_lsn = conn_info['break_at_current_lsn']
+    start_run_timestamp = datetime.datetime.utcnow()
     max_run_seconds = conn_info['max_run_seconds']
     logical_poll_total_seconds = conn_info['logical_poll_total_seconds'] or 300
     poll_interval = 10

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -352,13 +352,6 @@ def consume_message(streams, state, msg, time_extracted, conn_info, end_lsn):
     singer.write_message(record_message)
     state = singer.write_bookmark(state, target_stream['tap_stream_id'], 'lsn', lsn)
 
-    # Below is the behaviour of the original tap-progres to flush the source server wal to the latest lsn received in the current run
-    # The Pipelinewise version flushes only at the start of the next run to ensure the data has been comitted on the destination server
-    # if msg.data_start > end_lsn:
-    #     raise Exception("incorrectly attempting to flush an lsn({}) > end_lsn({})".format(msg.data_start, end_lsn))
-    # LOGGER.info("Confirming write up to {}, flush to {}".format(int_to_lsn(msg.data_start), int_to_lsn(msg.data_start)))
-    # msg.cursor.send_feedback(write_lsn=msg.data_start, flush_lsn=msg.data_start, reply=True)
-
     return state
 
 def locate_replication_slot(conn_info):

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -428,7 +428,7 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
             raise
 
         if msg:
-            if msg.data_start > end_lsn:
+            if (break_at_current_lsn) and (msg.data_start > end_lsn):
                 LOGGER.info("{} : Breaking - current {} is past end_lsn {}".format(datetime.datetime.utcnow(), int_to_lsn(msg.data_start), int_to_lsn(end_lsn)))
                 break
 
@@ -471,10 +471,10 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
                     LOGGER.warning("{} : Unable to open and parse {}".format(datetime.datetime.utcnow(), state_file))
                 finally:
                     lsn_comitted = min([get_bookmark(state_comitted, s['tap_stream_id'], 'lsn') for s in logical_streams])
-                    lsn_to_flush = lsn_comitted
-                    if lsn_currently_processing < lsn_to_flush: lsn_to_flush = lsn_currently_processing
-                    LOGGER.info("{} : Confirming write up to {}, flush to {}".format(datetime.datetime.utcnow(), int_to_lsn(lsn_to_flush), int_to_lsn(lsn_to_flush)))
-                    cur.send_feedback(write_lsn=lsn_to_flush, flush_lsn=lsn_to_flush, reply=True)
+                    if (lsn_currently_processing > lsn_comitted) and (lsn_comitted > lsn_to_flush):
+                        lsn_to_flush = lsn_comitted
+                        LOGGER.info("{} : Confirming write up to {}, flush to {}".format(datetime.datetime.utcnow(), int_to_lsn(lsn_to_flush), int_to_lsn(lsn_to_flush)))
+                        cur.send_feedback(write_lsn=lsn_to_flush, flush_lsn=lsn_to_flush, reply=True)
 
             poll_timestamp = datetime.datetime.utcnow()
 

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -378,7 +378,7 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
     lsn_comitted = min([get_bookmark(state_comitted, s['tap_stream_id'], 'lsn') for s in logical_streams])
     start_lsn = lsn_comitted
     lsn_to_flush = None
-    start_timestamp = datetime.datetime.utcnow()
+    start_run_timestamp = datetime.datetime.utcnow()
     time_extracted = utils.now()
     slot = locate_replication_slot(conn_info)
     lsn_last_processed = None
@@ -435,7 +435,7 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
                 LOGGER.info("{} : Breaking - current {} is past end_lsn {}".format(datetime.datetime.utcnow(), int_to_lsn(msg.data_start), int_to_lsn(end_lsn)))
                 break
 
-            if datetime.datetime.utcnow() >= (start_timestamp + datetime.timedelta(seconds=max_run_seconds)):
+            if datetime.datetime.utcnow() >= (start_run_timestamp + datetime.timedelta(seconds=max_run_seconds)):
                 LOGGER.info("{} : Breaking - reached max_run_seconds of {}".format(datetime.datetime.utcnow(), max_run_seconds))
                 break
 

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -409,10 +409,6 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
     except psycopg2.ProgrammingError:
         raise Exception("Unable to start replication with logical replication (slot {})".format(slot))
 
-    # Emulate some behaviour of pg_recvlogical
-    LOGGER.info("{} : Confirming write up to 0/0, flush to 0/0".format(datetime.datetime.utcnow()))
-    cur.send_feedback(write_lsn=0, flush_lsn=0, reply=True)
-
     lsn_received_timestamp = datetime.datetime.utcnow()
     poll_timestamp = datetime.datetime.utcnow()
 

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -378,13 +378,13 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
     lsn_comitted = min([get_bookmark(state_comitted, s['tap_stream_id'], 'lsn') for s in logical_streams])
     start_lsn = lsn_comitted
     lsn_to_flush = None
-    start_run_timestamp = datetime.datetime.utcnow()
     time_extracted = utils.now()
     slot = locate_replication_slot(conn_info)
     lsn_last_processed = None
     lsn_currently_processing = None
     lsn_received_timestamp = None
     lsn_processed_count = 0
+    start_run_timestamp = datetime.datetime.utcnow()
     break_at_current_lsn = conn_info['break_at_current_lsn']
     max_run_seconds = conn_info['max_run_seconds']
     logical_poll_total_seconds = conn_info['logical_poll_total_seconds'] or 300

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -432,7 +432,7 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
 
         if msg:
             if (break_at_current_lsn) and (msg.data_start > end_lsn):
-                LOGGER.info("{} : Breaking - current {} is past end_lsn {}".format(datetime.datetime.utcnow(), int_to_lsn(msg.data_start), int_to_lsn(end_lsn)))
+                LOGGER.info("{} : Breaking - latest wal message {} is past current_lsn captured at run start {}".format(datetime.datetime.utcnow(), int_to_lsn(msg.data_start), int_to_lsn(end_lsn)))
                 break
 
             if datetime.datetime.utcnow() >= (start_run_timestamp + datetime.timedelta(seconds=max_run_seconds)):

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -385,6 +385,8 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
     lsn_currently_processing = None
     lsn_received_timestamp = None
     lsn_processed_count = 0
+    break_at_current_lsn = conn_info['break_at_current_lsn']
+    maximum_run_seconds = conn_info['maximum_run_seconds']
     logical_poll_total_seconds = conn_info['logical_poll_total_seconds'] or 300
     poll_interval = 10
     poll_timestamp = None
@@ -473,7 +475,7 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
                     state_comitted_file = open(state_file)
                     state_comitted = json.load(state_comitted_file)
                 except:
-                    LOGGER.warning("{} : Unable to open and parse {}".format(datetime.datetime.utcnow(), state_file))
+                    LOGGER.info("{} : Unable to open and parse {}".format(datetime.datetime.utcnow(), state_file))
                 finally:
                     lsn_comitted = min([get_bookmark(state_comitted, s['tap_stream_id'], 'lsn') for s in logical_streams])
                     if (lsn_currently_processing > lsn_comitted) and (lsn_comitted > lsn_to_flush):

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -386,7 +386,7 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
     lsn_received_timestamp = None
     lsn_processed_count = 0
     break_at_current_lsn = conn_info['break_at_current_lsn']
-    maximum_run_seconds = conn_info['maximum_run_seconds']
+    max_run_seconds = conn_info['max_run_seconds']
     logical_poll_total_seconds = conn_info['logical_poll_total_seconds'] or 300
     poll_interval = 10
     poll_timestamp = None
@@ -435,8 +435,8 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
                 LOGGER.info("{} : Breaking - current {} is past end_lsn {}".format(datetime.datetime.utcnow(), int_to_lsn(msg.data_start), int_to_lsn(end_lsn)))
                 break
 
-            if datetime.datetime.utcnow() >= (start_timestamp + datetime.timedelta(seconds=maximum_run_seconds)):
-                LOGGER.info("{} : Breaking - reached maximum_run_seconds of {}".format(datetime.datetime.utcnow(), maximum_run_seconds))
+            if datetime.datetime.utcnow() >= (start_timestamp + datetime.timedelta(seconds=max_run_seconds)):
+                LOGGER.info("{} : Breaking - reached max_run_seconds of {}".format(datetime.datetime.utcnow(), max_run_seconds))
                 break
 
             state = consume_message(logical_streams, state, msg, time_extracted, conn_info, end_lsn)

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -384,9 +384,9 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
     lsn_currently_processing = None
     lsn_received_timestamp = None
     lsn_processed_count = 0
-    break_at_current_lsn = conn_info['break_at_current_lsn']
     start_run_timestamp = datetime.datetime.utcnow()
     max_run_seconds = conn_info['max_run_seconds']
+    break_at_current_lsn = conn_info['break_at_current_lsn']
     logical_poll_total_seconds = conn_info['logical_poll_total_seconds'] or 300
     poll_interval = 10
     poll_timestamp = None

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -386,7 +386,7 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
     lsn_processed_count = 0
     start_run_timestamp = datetime.datetime.utcnow()
     max_run_seconds = conn_info['max_run_seconds']
-    break_at_current_lsn = conn_info['break_at_current_lsn']
+    break_at_end_lsn = conn_info['break_at_end_lsn']
     logical_poll_total_seconds = conn_info['logical_poll_total_seconds'] or 300
     poll_interval = 10
     poll_timestamp = None
@@ -431,7 +431,7 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
             raise
 
         if msg:
-            if (break_at_current_lsn) and (msg.data_start > end_lsn):
+            if (break_at_end_lsn) and (msg.data_start > end_lsn):
                 LOGGER.info("{} : Breaking - latest wal message {} is past current_lsn captured at run start {}".format(datetime.datetime.utcnow(), int_to_lsn(msg.data_start), int_to_lsn(end_lsn)))
                 break
 


### PR DESCRIPTION
- create ability to set break_at_end_lsn
- create ability to set max_run_seconds
- only send feedback when lsn_comitted has increased
- remove some incompatible singer tap-postgres code
- bump version