### PR TITLE
[AP-473] Refactor logging

### DIFF
--- a/sample_logging.conf
+++ b/sample_logging.conf
@@ -1,0 +1,25 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=stderr
+
+[formatters]
+keys=child
+
+[logger_root]
+level=INFO
+handlers=stderr
+formatter=child
+propagate=0
+
+[handler_stderr]
+level=INFO
+class=StreamHandler
+formatter=child
+args=(sys.stderr,)
+
+[formatter_child]
+class=logging.Formatter
+format=time=%(asctime)s name=%(name)s level=%(levelname)s message=%(message)s
+datefmt=%Y-%m-%d %H:%M:%S

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 with open('README.md') as f:
-      long_description = f.read()
+    long_description = f.read()
 
 setup(name='pipelinewise-tap-postgres',
       version='1.3.1',
@@ -17,11 +17,16 @@ setup(name='pipelinewise-tap-postgres',
           'Programming Language :: Python :: 3 :: Only'
       ],
       install_requires=[
-          'singer-python==5.8.1',
+          'pipelinewise-singer-python==1.*',
           'psycopg2==2.8.4',
           'strict-rfc3339==0.7',
-          'nose==1.3.7'
       ],
+      extras_require={
+          "test": [
+              'nose==1.3.7',
+              'pylint==2.4.2'
+          ]
+      },
       entry_points='''
           [console_scripts]
           tap-postgres=tap_postgres:main

--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -26,9 +26,11 @@ import tap_postgres.sync_strategies.full_table as full_table
 import tap_postgres.sync_strategies.incremental as incremental
 import tap_postgres.db as post_db
 import tap_postgres.sync_strategies.common as sync_common
-LOGGER = singer.get_logger()
 
-#LogMiner do not support LONG, LONG RAW, CLOB, BLOB, NCLOB, ADT, or COLLECTION datatypes.
+
+LOGGER = singer.get_logger('tap_postgres')
+
+# LogMiner do not support LONG, LONG RAW, CLOB, BLOB, NCLOB, ADT, or COLLECTION datatypes.
 Column = collections.namedtuple('Column', [
     "column_name",
     "is_primary_key",

--- a/tap_postgres/db.py
+++ b/tap_postgres/db.py
@@ -8,7 +8,8 @@ import math
 import psycopg2
 import psycopg2.extras
 import singer
-LOGGER = singer.get_logger()
+
+LOGGER = singer.get_logger('tap_postgres')
 
 cursor_iter_size = 20000
 

--- a/tap_postgres/sync_strategies/full_table.py
+++ b/tap_postgres/sync_strategies/full_table.py
@@ -10,7 +10,7 @@ from singer import utils
 import singer.metrics as metrics
 import tap_postgres.db as post_db
 
-LOGGER = singer.get_logger()
+LOGGER = singer.get_logger('tap_postgres')
 
 UPDATE_BOOKMARK_PERIOD = 1000
 

--- a/tap_postgres/sync_strategies/incremental.py
+++ b/tap_postgres/sync_strategies/incremental.py
@@ -8,7 +8,7 @@ import singer.metrics as metrics
 import tap_postgres.db as post_db
 
 
-LOGGER = singer.get_logger()
+LOGGER = singer.get_logger('tap_postgres')
 
 UPDATE_BOOKMARK_PERIOD = 10000
 

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -3,22 +3,19 @@
 
 import singer
 import datetime
-import time
 import pytz
 import decimal
-from singer import utils, get_bookmark
+import psycopg2
+import copy
+import json
 import singer.metadata as metadata
 import tap_postgres.db as post_db
 import tap_postgres.sync_strategies.common as sync_common
+from singer import utils, get_bookmark
 from dateutil.parser import parse
-import psycopg2
-import copy
-from select import select
 from functools import reduce
-import json
-import re
 
-LOGGER = singer.get_logger()
+LOGGER = singer.get_logger('tap_postgres')
 
 UPDATE_BOOKMARK_PERIOD = 10000
 


### PR DESCRIPTION
Switch to pipelinewise-singer-python to be able to customize logging.

If `LOGGING_CONF_FILE` env variable points to a logging file like this:

```
[loggers]
keys=root

[handlers]
keys=stderr

[formatters]
keys=child

[logger_root]
level=INFO
handlers=stderr
formatter=child
propagate=0

[handler_stderr]
level=INFO
class=StreamHandler
formatter=child
args=(sys.stderr,)

[formatter_child]
class=logging.Formatter
format=time=%(asctime)s name=%(name)s level=%(levelname)s message=%(message)s
datefmt=%Y-%m-%d %H:%M:%S

```

Then the logs would look like this
```
time=2020-02-06 17:31:03 name=tap_postgres level=INFO message=Selected streams: ['public-test_table'] 
time=2020-02-06 17:31:03 name=tap_postgres level=INFO message=end_lsn = 26690208 
time=2020-02-06 17:31:03 name=tap_postgres level=INFO message=No streams marked as currently_syncing in state file
time=2020-02-06 17:31:03 name=tap_postgres level=INFO message=Beginning sync of stream(public-test_table) with sync method(logical_initial)
time=2020-02-06 17:31:03 name=tap_postgres level=INFO message=Performing initial full table sync
time=2020-02-06 17:31:03 name=tap_postgres level=INFO message=Current Server Encoding: UTF8
time=2020-02-06 17:31:03 name=tap_postgres level=INFO message=Current Client Encoding: UTF8
time=2020-02-06 17:31:03 name=tap_postgres level=INFO message=hstore is available
time=2020-02-06 17:31:03 name=tap_postgres level=INFO message=Beginning new Full Table replication 1581003063531
time=2020-02-06 17:31:03 name=tap_postgres level=INFO message=select SELECT  "country" , "created_at" , "id" , "language" , xmin::text::bigint
                                      FROM "public"."test_table"
                                     ORDER BY xmin::text ASC with itersize 20000
time=2020-02-06 17:31:03 name=singer level=INFO message=METRIC: {"type": "counter", "metric": "record_count", "value": 0, "tags": {}}

```