### PR TITLE
[AP-659] Fix extracting data from tables with space in the name

### DIFF
--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -401,12 +401,13 @@ def locate_replication_slot(conn_info):
             raise Exception("Unable to find replication slot {} with wal2json".format(db_specific_slot))
 
 
+# pylint: disable=anomalous-backslash-in-string
 def streams_to_wal2json_tables(streams):
     """Converts a list of singer stream dictionaries to wal2json plugin compatible string list.
     The output is compatible with the 'filter-tables' and 'add-tables' option of wal2json plugin.
 
     Special characters (space, single quote, comma, period, asterisk) must be escaped with backslash.
-    Schema and table are case-sensitive. Table "public"."Foo bar" should be specified as public. Foo\ bar.
+    Schema and table are case-sensitive. Table "public"."Foo bar" should be specified as "public.Foo\ bar".
     Documentation in wal2json plugin: https://github.com/eulerto/wal2json/blob/master/README.md#parameters
 
     :param streams: List of singer stream dictionaries

--- a/tests/test_logical_replication.py
+++ b/tests/test_logical_replication.py
@@ -1,0 +1,41 @@
+import unittest
+
+from tap_postgres.sync_strategies import logical_replication
+
+
+class TestLogicalReplication(unittest.TestCase):
+    maxDiff = None
+
+    def setUp(self):
+        pass
+
+    def test_streams_to_wal2json_tables(self):
+        """Validate if table names are escaped to wal2json format"""
+        streams = [
+            {'metadata': [{'metadata': {'schema-name': 'public'}}],
+             'table_name': 'dummy_table'},
+            {'metadata': [{'metadata': {'schema-name': 'public'}}],
+             'table_name': 'CaseSensitiveTable'},
+            {'metadata': [{'metadata': {'schema-name': 'public'}}],
+             'table_name': 'Case Sensitive Table With Space'},
+            {'metadata': [{'metadata': {'schema-name': 'CaseSensitiveSchema'}}],
+             'table_name': 'dummy_table'},
+            {'metadata': [{'metadata': {'schema-name': 'Case Sensitive Schema With Space'}}],
+             'table_name': 'CaseSensitiveTable'},
+            {'metadata': [{'metadata': {'schema-name': 'Case Sensitive Schema With Space'}}],
+             'table_name': 'Case Sensitive Table With Space'},
+            {'metadata': [{'metadata': {'schema-name': 'public'}}],
+             'table_name': 'table_with_comma_,'},
+            {'metadata': [{'metadata': {'schema-name': 'public'}}],
+             'table_name': "table_with_quote_'"}
+        ]
+
+        self.assertEqual(logical_replication.streams_to_wal2json_tables(streams),
+                         'public.dummy_table,'
+                         'public.CaseSensitiveTable,'
+                         'public.Case\\ Sensitive\\ Table\\ With\\ Space,'
+                         'CaseSensitiveSchema.dummy_table,'
+                         'Case\\ Sensitive\\ Schema\\ With\\ Space.CaseSensitiveTable,'
+                         'Case\\ Sensitive\\ Schema\\ With\\ Space.Case\\ Sensitive\\ Table\\ With\\ Space,'
+                         'public.table_with_comma_\\,,'
+                         "public.table_with_quote_\\'")


### PR DESCRIPTION
This PR fixes an issue when `LOG_BASED` method can't extract data from tables with space in the name.

This is due to a specific string escape method required by wal2json plugin. More info about the correct formatting at https://github.com/eulerto/wal2json/blob/master/README.md#parameters  wal2json escape strings in the `filter-tables` and `add-tables` section. 