### PR TITLE
[AP-655] Handle to LOG_BASED replicate muliple databases by multiple taps

### DIFF
--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -396,6 +396,7 @@ def discover_columns(connection, table_info):
 
 
 def discover_db(connection, filter_schemas=None):
+    LOGGER.info("Discovering db %s", connection['dbname'])
     table_info = produce_table_info(connection, filter_schemas)
     db_streams = discover_columns(connection, table_info)
     return db_streams

--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -396,7 +396,6 @@ def discover_columns(connection, table_info):
 
 
 def discover_db(connection, filter_schemas=None):
-    LOGGER.info("Discovering db %s", connection['dbname'])
     table_info = produce_table_info(connection, filter_schemas)
     db_streams = discover_columns(connection, table_info)
     return db_streams
@@ -422,6 +421,7 @@ def dump_catalog(all_streams):
 
 def do_discovery(conn_config):
     with post_db.open_connection(conn_config) as conn:
+        LOGGER.info("Discovering db %s", conn_config['dbname'])
         streams = discover_db(conn, conn_config.get('filter_schemas'))
 
     if len(streams) == 0:

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -4,7 +4,6 @@ import decimal
 import psycopg2
 from psycopg2 import sql
 import copy
-import random
 import json
 import singer
 import singer.metadata as metadata

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -420,7 +420,7 @@ def locate_replication_slot(conn_info):
     with post_db.open_connection(conn_info, False) as conn:
         with conn.cursor() as cur:
             db_specific_slot = generate_replication_slot_name(dbname=conn_info['dbname'],
-                                                              tap_id=conn_info.get('tap_id'))
+                                                              tap_id=conn_info['tap_id'])
 
             cur.execute("SELECT * FROM pg_replication_slots WHERE slot_name = %s AND plugin = %s",
                         (db_specific_slot, 'wal2json'))

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -18,8 +18,8 @@ import tap_postgres.sync_strategies.common as sync_common
 LOGGER = singer.get_logger('tap_postgres')
 
 UPDATE_BOOKMARK_PERIOD = 10000
-MIN_GENERATED_TAP_ID = 900000000        # Used to generate random tap_id if not provided by by config.json
-MAX_GENERATED_TAP_ID = 999999999        # Used to generate random tap_id if not provided by by config.json
+MIN_GENERATED_TAP_ID = 900000000        # To generate random tap_id if not provided in config.json
+MAX_GENERATED_TAP_ID = 999999999        # To generate random tap_id if not provided in config.json
 
 
 # pylint: disable=invalid-name,missing-function-docstring,too-many-branches,too-many-statements,too-many-arguments

--- a/tests/test_logical_replication.py
+++ b/tests/test_logical_replication.py
@@ -49,7 +49,7 @@ class TestLogicalReplication(unittest.TestCase):
 
     def test_generate_replication_slot_name(self):
         """Validate if the replication slot name generated correctly"""
-        # Provide only database name: tap_id should be generated
+        # Provide only database name: tap_id should be generated as a random big number
         self.assertTrue(re.compile('^pipelinewise_some_db_\d+$').match(
             logical_replication.generate_replication_slot_name('some_db')))
 

--- a/tests/test_logical_replication.py
+++ b/tests/test_logical_replication.py
@@ -1,5 +1,4 @@
 import unittest
-import re
 
 from tap_postgres.sync_strategies import logical_replication
 
@@ -41,17 +40,11 @@ class TestLogicalReplication(unittest.TestCase):
                          'public.table_with_comma_\\,,'
                          "public.table_with_quote_\\'")
 
-    def test_generate_tap_id(self):
-        """Validate if the generated tap_id is between the MIN and MAX range"""
-        self.assertTrue(logical_replication.MIN_GENERATED_TAP_ID <
-                        logical_replication.generate_tap_id() <=
-                        logical_replication.MAX_GENERATED_TAP_ID)
-
     def test_generate_replication_slot_name(self):
         """Validate if the replication slot name generated correctly"""
-        # Provide only database name: tap_id should be generated as a random big number
-        self.assertTrue(re.compile('^pipelinewise_some_db_\d+$').match(
-            logical_replication.generate_replication_slot_name('some_db')))
+        # Provide only database name
+        self.assertEquals(logical_replication.generate_replication_slot_name('some_db'),
+                          'pipelinewise_some_db')
 
         # Provide database name and tap_id
         self.assertEquals(logical_replication.generate_replication_slot_name('some_db',
@@ -64,7 +57,7 @@ class TestLogicalReplication(unittest.TestCase):
                                                                              prefix='custom_prefix'),
                           'custom_prefix_some_db_some_tap')
 
-        # Replication slot name should be lowercased
+        # Replication slot name should be lowercase
         self.assertEquals(logical_replication.generate_replication_slot_name('SoMe_DB',
                                                                              'SoMe_TaP'),
                           'pipelinewise_some_db_some_tap')

--- a/tests/test_logical_replication.py
+++ b/tests/test_logical_replication.py
@@ -1,4 +1,5 @@
 import unittest
+import re
 
 from tap_postgres.sync_strategies import logical_replication
 
@@ -39,3 +40,32 @@ class TestLogicalReplication(unittest.TestCase):
                          'Case\\ Sensitive\\ Schema\\ With\\ Space.Case\\ Sensitive\\ Table\\ With\\ Space,'
                          'public.table_with_comma_\\,,'
                          "public.table_with_quote_\\'")
+
+    def test_generate_tap_id(self):
+        """Validate if the generated tap_id is between the MIN and MAX range"""
+        self.assertTrue(logical_replication.MIN_GENERATED_TAP_ID <
+                        logical_replication.generate_tap_id() <=
+                        logical_replication.MAX_GENERATED_TAP_ID)
+
+    def test_generate_replication_slot_name(self):
+        """Validate if the replication slot name generated correctly"""
+        # Provide only database name: tap_id should be generated
+        self.assertTrue(re.compile('^pipelinewise_some_db_\d+$').match(
+            logical_replication.generate_replication_slot_name('some_db')))
+
+        # Provide database name and tap_id
+        self.assertEquals(logical_replication.generate_replication_slot_name('some_db',
+                                                                             'some_tap'),
+                          'pipelinewise_some_db_some_tap')
+
+        # Provide database name, tap_id and prefix
+        self.assertEquals(logical_replication.generate_replication_slot_name('some_db',
+                                                                             'some_tap',
+                                                                             prefix='custom_prefix'),
+                          'custom_prefix_some_db_some_tap')
+
+        # Replication slot name should be lowercased
+        self.assertEquals(logical_replication.generate_replication_slot_name('SoMe_DB',
+                                                                             'SoMe_TaP'),
+                          'pipelinewise_some_db_some_tap')
+


### PR DESCRIPTION
This PR makes possible to `LOG_BASE` replicate multiple database in the same postgres instance by multiple parallel running taps.

**Changes**
* Discovering only the database that provided in the `config.json`. Replicating multiple databases requires multiple taps.
* Generating unique replication slot names dynamically
* Removed the `filter_dbs` optional parameter
* Test cases
* Docstrings in new functions
* Fixing some identations