### PR TITLE
Ap 655 renamed

### DIFF
--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -20,7 +20,7 @@ UPDATE_BOOKMARK_PERIOD = 10000
 
 
 class ReplicationSlotNotFoundError(Exception):
-    pass
+    """Custom exception when replication slot not found"""
 
 
 # pylint: disable=invalid-name,missing-function-docstring,too-many-branches,too-many-statements,too-many-arguments

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -417,13 +417,13 @@ def locate_replication_slot_by_cur(cursor, dbname, tap_id=None):
     # Backward compatibility: try to locate existing v15 slot first. PPW <= 0.15.0
     cursor.execute(f"SELECT * FROM pg_replication_slots WHERE slot_name = '{slot_name_v15}'")
     if len(cursor.fetchall()) == 1:
-        LOGGER.info("Using pg_replication_slot %s", slot_name_v15)
+        LOGGER.info('Using pg_replication_slot %s', slot_name_v15)
         return slot_name_v15
 
     # v15 style replication slot not found, try to locate v16
     cursor.execute(f"SELECT * FROM pg_replication_slots WHERE slot_name = '{slot_name_v16}'")
     if len(cursor.fetchall()) == 1:
-        LOGGER.info("Using pg_replication_slot %s", slot_name_v16)
+        LOGGER.info('Using pg_replication_slot %s', slot_name_v16)
         return slot_name_v16
 
     raise ReplicationSlotNotFoundError(f'Unable to find replication slot {slot_name_v16}')

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -19,6 +19,10 @@ LOGGER = singer.get_logger('tap_postgres')
 UPDATE_BOOKMARK_PERIOD = 10000
 
 
+class ReplicationSlotNotFoundError(Exception):
+    pass
+
+
 # pylint: disable=invalid-name,missing-function-docstring,too-many-branches,too-many-statements,too-many-arguments
 def get_pg_version(conn_info):
     with post_db.open_connection(conn_info, False) as conn:
@@ -406,19 +410,29 @@ def generate_replication_slot_name(dbname, tap_id=None, prefix='pipelinewise'):
     return f'{prefix}_{dbname}{tap_id}'.lower()
 
 
+def locate_replication_slot_by_cur(cursor, dbname, tap_id=None):
+    slot_name_v15 = generate_replication_slot_name(dbname)
+    slot_name_v16 = generate_replication_slot_name(dbname, tap_id)
+
+    # Backward compatibility: try to locate existing v15 slot first. PPW <= 0.15.0
+    cursor.execute(f"SELECT * FROM pg_replication_slots WHERE slot_name = '{slot_name_v15}'")
+    if len(cursor.fetchall()) == 1:
+        LOGGER.info("Using pg_replication_slot %s", slot_name_v15)
+        return slot_name_v15
+
+    # v15 style replication slot not found, try to locate v16
+    cursor.execute(f"SELECT * FROM pg_replication_slots WHERE slot_name = '{slot_name_v16}'")
+    if len(cursor.fetchall()) == 1:
+        LOGGER.info("Using pg_replication_slot %s", slot_name_v16)
+        return slot_name_v16
+
+    raise ReplicationSlotNotFoundError(f'Unable to find replication slot {slot_name_v16}')
+
+
 def locate_replication_slot(conn_info):
     with post_db.open_connection(conn_info, False) as conn:
         with conn.cursor() as cur:
-            db_specific_slot = generate_replication_slot_name(dbname=conn_info['dbname'],
-                                                              tap_id=conn_info['tap_id'])
-
-            cur.execute("SELECT * FROM pg_replication_slots WHERE slot_name = %s AND plugin = %s",
-                        (db_specific_slot, 'wal2json'))
-            if len(cur.fetchall()) == 1:
-                LOGGER.info("Using pg_replication_slot %s", db_specific_slot)
-                return db_specific_slot
-
-            raise Exception("Unable to find replication slot {} with wal2json".format(db_specific_slot))
+            return locate_replication_slot_by_cur(cur, conn_info['dbname'], conn_info['tap_id'])
 
 
 # pylint: disable=anomalous-backslash-in-string

--- a/tests/test_logical_replication.py
+++ b/tests/test_logical_replication.py
@@ -3,6 +3,30 @@ import unittest
 from tap_postgres.sync_strategies import logical_replication
 
 
+class PostgresCurReplicationSlotMock:
+    """
+    Postgres Cursor Mock with replication slot selection
+    """
+
+    def __init__(self, existing_slot_name):
+        """Initialise by defining an existing replication slot"""
+        self.existing_slot_name = existing_slot_name
+        self.replication_slot_found = False
+
+    def execute(self, sql):
+        """Simulating to run an SQL query
+        If the query is selecting the existing_slot_name then the replication slot found"""
+        if sql == f"SELECT * FROM pg_replication_slots WHERE slot_name = '{self.existing_slot_name}'":
+            self.replication_slot_found = True
+
+    def fetchall(self):
+        """Return the replication slot name as a List if the slot exists."""
+        if self.replication_slot_found:
+            return [self.existing_slot_name]
+
+        return []
+
+
 class TestLogicalReplication(unittest.TestCase):
     maxDiff = None
 
@@ -62,3 +86,32 @@ class TestLogicalReplication(unittest.TestCase):
                                                                              'SoMe_TaP'),
                           'pipelinewise_some_db_some_tap')
 
+    def test_locate_replication_slot_by_cur(self):
+        """Validate if both v15 and v16 style replication slot located correctly"""
+        # Should return v15 style slot name if v15 style replication slot exists
+        cursor = PostgresCurReplicationSlotMock(existing_slot_name='pipelinewise_some_db')
+        self.assertEquals(logical_replication.locate_replication_slot_by_cur(cursor,
+                                                                             'some_db',
+                                                                             'some_tap'),
+                          'pipelinewise_some_db')
+
+        # Should return v16 style slot name if v16 style replication slot exists
+        cursor = PostgresCurReplicationSlotMock(existing_slot_name='pipelinewise_some_db_some_tap')
+        self.assertEquals(logical_replication.locate_replication_slot_by_cur(cursor,
+                                                                             'some_db',
+                                                                             'some_tap'),
+                          'pipelinewise_some_db_some_tap')
+
+        # Should return v15 style replication slot if tap_id not provided and the v15 slot exists
+        cursor = PostgresCurReplicationSlotMock(existing_slot_name='pipelinewise_some_db')
+        self.assertEquals(logical_replication.locate_replication_slot_by_cur(cursor,
+                                                                             'some_db'),
+                          'pipelinewise_some_db')
+
+        # Should raise an exception if no v15 or v16 style replication slot found
+        cursor = PostgresCurReplicationSlotMock(existing_slot_name=None)
+        with self.assertRaises(logical_replication.ReplicationSlotNotFoundError):
+            self.assertEquals(logical_replication.locate_replication_slot_by_cur(cursor,
+                                                                                 'some_db',
+                                                                                 'some_tap'),
+                              'pipelinewise_some_db_some_tap')


### PR DESCRIPTION
Replication slot naming pattern is about to change starting from PPW 0.16.0 to allow log based replication from the same database by multiple taps. The naming patterns:

```
 <PPW 0.16.0: pipelinewise_<dbname>
>=PPW 0.16.0: pipelinewise_<dbname>_<tap_id>
```

At the same time we don't want to reconfigure all the existing taps and re-create the replication slots when upgrading the PPW. Instead of this the tap should find the old replication slot with the old name if exists and should keep using it.

This logic was implemented in the fastsync by https://github.com/transferwise/pipelinewise/pull/388 but the similar change not added here to tap-postgres