### PR TITLE
[AP-655] Fixed an issue when existing replication slot not found

### DIFF
--- a/tests/test_logical_replication.py
+++ b/tests/test_logical_replication.py
@@ -3,6 +3,30 @@ import unittest
 from tap_postgres.sync_strategies import logical_replication
 
 
+class PostgresCurReplicationSlotMock:
+    """
+    Postgres Cursor Mock with replication slot selection
+    """
+
+    def __init__(self, existing_slot_name):
+        """Initialise by defining an existing replication slot"""
+        self.existing_slot_name = existing_slot_name
+        self.replication_slot_found = False
+
+    def execute(self, sql):
+        """Simulating to run an SQL query
+        If the query is selecting the existing_slot_name then the replication slot found"""
+        if sql == f"SELECT * FROM pg_replication_slots WHERE slot_name = '{self.existing_slot_name}'":
+            self.replication_slot_found = True
+
+    def fetchall(self):
+        """Return the replication slot name as a List if the slot exists."""
+        if self.replication_slot_found:
+            return [self.existing_slot_name]
+
+        return []
+
+
 class TestLogicalReplication(unittest.TestCase):
     maxDiff = None
 
@@ -61,4 +85,34 @@ class TestLogicalReplication(unittest.TestCase):
         self.assertEquals(logical_replication.generate_replication_slot_name('SoMe_DB',
                                                                              'SoMe_TaP'),
                           'pipelinewise_some_db_some_tap')
+
+    def test_locate_replication_slot_by_cur(self):
+        """Validate if both v15 and v16 style replication slot located correctly"""
+        # Should return v15 style slot name if v15 style replication slot exists
+        cursor = PostgresCurReplicationSlotMock(existing_slot_name='pipelinewise_some_db')
+        self.assertEquals(logical_replication.locate_replication_slot_by_cur(cursor,
+                                                                             'some_db',
+                                                                             'some_tap'),
+                          'pipelinewise_some_db')
+
+        # Should return v16 style slot name if v16 style replication slot exists
+        cursor = PostgresCurReplicationSlotMock(existing_slot_name='pipelinewise_some_db_some_tap')
+        self.assertEquals(logical_replication.locate_replication_slot_by_cur(cursor,
+                                                                             'some_db',
+                                                                             'some_tap'),
+                          'pipelinewise_some_db_some_tap')
+
+        # Should return v15 style replication slot if tap_id not provided and the v15 slot exists
+        cursor = PostgresCurReplicationSlotMock(existing_slot_name='pipelinewise_some_db')
+        self.assertEquals(logical_replication.locate_replication_slot_by_cur(cursor,
+                                                                             'some_db'),
+                          'pipelinewise_some_db')
+
+        # Should raise an exception if no v15 or v16 style replication slot found
+        cursor = PostgresCurReplicationSlotMock(existing_slot_name=None)
+        with self.assertRaises(logical_replication.ReplicationSlotNotFoundError):
+            self.assertEquals(logical_replication.locate_replication_slot_by_cur(cursor,
+                                                                                 'some_db',
+                                                                                 'some_tap'),
+                              'pipelinewise_some_db_some_tap')
 


### PR DESCRIPTION
Replication slot naming pattern is about to change starting from PPW 0.16.0 to allow log based replication from the same database by multiple taps. The naming patterns:

```
 <PPW 0.16.0: pipelinewise_<dbname>
>=PPW 0.16.0: pipelinewise_<dbname>_<tap_id>
```

At the same time we don't want to reconfigure all the existing taps and re-create the replication slots when upgrading the PPW. Instead of this the tap should find the old replication slot with the old name if exists and should keep using it.

This logic was implemented in the fastsync by https://github.com/transferwise/pipelinewise/pull/388 but the similar change not added here to tap-postgres