### PR TITLE
[AP-700] Fixed issue when JSON type not converted to dictionary

### DIFF
--- a/tap_postgres/db.py
+++ b/tap_postgres/db.py
@@ -81,7 +81,7 @@ def selected_value_to_singer_value_impl(elem, sql_datatype):
         cleaned_elem = elem
     elif sql_datatype == 'money':
         cleaned_elem = elem
-    elif sql_datatype == 'jsonb':
+    elif sql_datatype in ['json', 'jsonb']:
         cleaned_elem = json.loads(elem)
     elif sql_datatype == 'time with time zone':
         # time with time zone values will be converted to UTC and time zone dropped

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -17,8 +17,8 @@ class TestDbFunctions(unittest.TestCase):
 
         # time with time zone values should be converted to UTC and time zone dropped
         # Hour 24 should be taken as 0
-        self.assertEqual(db.selected_value_to_singer_value_impl('12:00:00-08:00', 'time with time zone'), '20:00:00')
-        self.assertEqual(db.selected_value_to_singer_value_impl('24:00:00-08:00', 'time with time zone'), '08:00:00')
+        self.assertEqual(db.selected_value_to_singer_value_impl('12:00:00-0800', 'time with time zone'), '20:00:00')
+        self.assertEqual(db.selected_value_to_singer_value_impl('24:00:00-0800', 'time with time zone'), '08:00:00')
 
         # time without time zone values should be converted to UTC and time zone dropped
         self.assertEqual(db.selected_value_to_singer_value_impl('12:00:00', 'time without time zone'), '12:00:00')
@@ -26,9 +26,9 @@ class TestDbFunctions(unittest.TestCase):
         self.assertEqual(db.selected_value_to_singer_value_impl('24:00:00', 'time without time zone'), '00:00:00')
 
         # timestamp with time zone should be converted to iso format
-        self.assertEqual(db.selected_value_to_singer_value_impl('2020-05-01T12:00:00-08:00',
+        self.assertEqual(db.selected_value_to_singer_value_impl('2020-05-01T12:00:00-0800',
                                                                 'timestamp with time zone'),
-                         '2020-05-01T12:00:00-08:00')
+                         '2020-05-01T12:00:00-0800')
 
         # bit should be True only if elem is '1'
         self.assertEqual(db.selected_value_to_singer_value_impl('1', 'bit'), True)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -3,7 +3,7 @@ import unittest
 from tap_postgres import db
 
 
-class ValueToSingerValue(unittest.TestCase):
+class TestDbFunctions(unittest.TestCase):
     maxDiff = None
 
     def setUp(self):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,43 @@
+import unittest
+
+from tap_postgres import db
+
+
+class ValueToSingerValue(unittest.TestCase):
+    maxDiff = None
+
+    def setUp(self):
+        pass
+
+    def test_value_to_singer_value(self):
+        """Test if every element converted from sql_datatype to the correct singer type"""
+        # JSON and JSONB should be converted to dictionaries
+        self.assertEqual(db.selected_value_to_singer_value_impl('{"test": 123}', 'json'), {'test': 123})
+        self.assertEqual(db.selected_value_to_singer_value_impl('{"test": 123}', 'jsonb'), {'test': 123})
+
+        # time with time zone values should be converted to UTC and time zone dropped
+        # Hour 24 should be taken as 0
+        self.assertEqual(db.selected_value_to_singer_value_impl('12:00:00-08:00', 'time with time zone'), '20:00:00')
+        self.assertEqual(db.selected_value_to_singer_value_impl('24:00:00-08:00', 'time with time zone'), '08:00:00')
+
+        # time without time zone values should be converted to UTC and time zone dropped
+        self.assertEqual(db.selected_value_to_singer_value_impl('12:00:00', 'time without time zone'), '12:00:00')
+        # Hour 24 should be taken as 0
+        self.assertEqual(db.selected_value_to_singer_value_impl('24:00:00', 'time without time zone'), '00:00:00')
+
+        # timestamp with time zone should be converted to iso format
+        self.assertEqual(db.selected_value_to_singer_value_impl('2020-05-01T12:00:00-08:00',
+                                                                'timestamp with time zone'),
+                         '2020-05-01T12:00:00-08:00')
+
+        # bit should be True only if elem is '1'
+        self.assertEqual(db.selected_value_to_singer_value_impl('1', 'bit'), True)
+        self.assertEqual(db.selected_value_to_singer_value_impl('0', 'bit'), False)
+        self.assertEqual(db.selected_value_to_singer_value_impl(1, 'bit'), False)
+        self.assertEqual(db.selected_value_to_singer_value_impl(0, 'bit'), False)
+
+        # boolean should be True in case of numeric 1 and logical True
+        self.assertEqual(db.selected_value_to_singer_value_impl(1, 'boolean'), True)
+        self.assertEqual(db.selected_value_to_singer_value_impl(True, 'boolean'), True)
+        self.assertEqual(db.selected_value_to_singer_value_impl(0, 'boolean'), False)
+        self.assertEqual(db.selected_value_to_singer_value_impl(False, 'boolean'), False)


### PR DESCRIPTION
Fixed an issue when `JSON` type not converted to python dictionary and the value passed as string in the singer output message. The conversion was working only for `JSONB` but not for `JSON`.

This PR adds some additional tests for other data type conversions.