### PR TITLE
[AP-369] Handle timestamps out of range

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,14 +45,14 @@ jobs:
           name: 'Pylinting'
           command: |
             . ./virtualenvs/tap-postgres/bin/activate
-            make pylint
+            pylint --rcfile .pylintrc --disable duplicate-code tap_postgres/
 
       - run:
           name: 'Tests'
           command: |
             . ./virtualenvs/tap-postgres/bin/activate
             export LOGGING_CONF_FILE=./sample_logging.conf
-            make test
+            pytest --cov=tap_postgres  --cov-fail-under=59 tests -v
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,14 +45,14 @@ jobs:
           name: 'Pylinting'
           command: |
             . ./virtualenvs/tap-postgres/bin/activate
-            pylint --rcfile .pylintrc --disable duplicate-code tap_postgres/
+            make pylint
 
       - run:
           name: 'Tests'
           command: |
             . ./virtualenvs/tap-postgres/bin/activate
             export LOGGING_CONF_FILE=./sample_logging.conf
-            pytest --cov=tap_postgres tests
+            make test
 
 workflows:
   version: 2

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 pylint:
-	pylint --rcfile .pylintrc tap_postgres
+	pylint --rcfile .pylintrc --disable duplicate-code tap_postgres/
 
 test:
-	pytest --cov=tap_postgres tests -v
+	pytest --cov=tap_postgres  --cov-fail-under=59 tests -v

--- a/tap_postgres/db.py
+++ b/tap_postgres/db.py
@@ -59,6 +59,16 @@ def open_connection(conn_config, logical_replication=False):
 
     return conn
 
+def prepare_columns_for_select_sql(c, md_map):
+    column_name = ' "{}" '.format(canonicalize_identifier(c))
+
+    if ('properties', c) in md_map and md_map[('properties', c)]['sql-datatype'].startswith('timestamp'):
+        return f'CASE ' \
+               f'WHEN {column_name} < \'0001-01-01 00:00:00.000000\' ' \
+               f'OR {column_name} > \'9999-12-31 23:59:59.999999\' THEN \'9999-12-31 23:59:59.999999\' ' \
+               f'ELSE {column_name} ' \
+               f'END AS {column_name}'
+    return column_name
 
 def prepare_columns_sql(c):
     column_name = """ "{}" """.format(canonicalize_identifier(c))

--- a/tap_postgres/db.py
+++ b/tap_postgres/db.py
@@ -64,8 +64,8 @@ def prepare_columns_for_select_sql(c, md_map):
 
     if ('properties', c) in md_map and md_map[('properties', c)]['sql-datatype'].startswith('timestamp'):
         return f'CASE ' \
-               f'WHEN {column_name} < \'0001-01-01 00:00:00.000000\' ' \
-               f'OR {column_name} > \'9999-12-31 23:59:59.999999\' THEN \'9999-12-31 23:59:59.999\' ' \
+               f'WHEN {column_name} < \'0001-01-01 00:00:00.000\' ' \
+               f'OR {column_name} > \'9999-12-31 23:59:59.999\' THEN \'9999-12-31 23:59:59.999\' ' \
                f'ELSE {column_name} ' \
                f'END AS {column_name}'
     return column_name

--- a/tap_postgres/db.py
+++ b/tap_postgres/db.py
@@ -65,7 +65,7 @@ def prepare_columns_for_select_sql(c, md_map):
     if ('properties', c) in md_map and md_map[('properties', c)]['sql-datatype'].startswith('timestamp'):
         return f'CASE ' \
                f'WHEN {column_name} < \'0001-01-01 00:00:00.000000\' ' \
-               f'OR {column_name} > \'9999-12-31 23:59:59.999999\' THEN \'9999-12-31 23:59:59.999999\' ' \
+               f'OR {column_name} > \'9999-12-31 23:59:59.999999\' THEN \'9999-12-31 23:59:59.999\' ' \
                f'ELSE {column_name} ' \
                f'END AS {column_name}'
     return column_name

--- a/tap_postgres/sync_strategies/full_table.py
+++ b/tap_postgres/sync_strategies/full_table.py
@@ -3,7 +3,10 @@ import time
 import psycopg2
 import psycopg2.extras
 import singer
+
+from functools import partial
 from singer import utils
+
 import singer.metrics as metrics
 import tap_postgres.db as post_db
 
@@ -91,7 +94,7 @@ def sync_table(conn_info, stream, state, desired_columns, md_map):
 
     schema_name = md_map.get(()).get('schema-name')
 
-    escaped_columns = map(post_db.prepare_columns_sql, desired_columns)
+    escaped_columns = map(partial(post_db.prepare_columns_for_select_sql, md_map=md_map), desired_columns)
 
     activate_version_message = singer.ActivateVersionMessage(
         stream=post_db.calculate_destination_stream_name(stream, md_map),

--- a/tap_postgres/sync_strategies/incremental.py
+++ b/tap_postgres/sync_strategies/incremental.py
@@ -3,7 +3,10 @@ import time
 import psycopg2
 import psycopg2.extras
 import singer
+
 from singer import utils
+from functools import partial
+
 import singer.metrics as metrics
 import tap_postgres.db as post_db
 
@@ -43,7 +46,7 @@ def sync_table(conn_info, stream, state, desired_columns, md_map):
 
     schema_name = md_map.get(()).get('schema-name')
 
-    escaped_columns = map(post_db.prepare_columns_sql, desired_columns)
+    escaped_columns = map(partial(post_db.prepare_columns_for_select_sql, md_map=md_map), desired_columns)
 
     activate_version_message = singer.ActivateVersionMessage(
         stream=post_db.calculate_destination_stream_name(stream, md_map),

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -20,7 +20,7 @@ from tap_postgres.stream_utils import refresh_streams_schema
 LOGGER = singer.get_logger('tap_postgres')
 
 UPDATE_BOOKMARK_PERIOD = 10000
-FALLBACK_DATETIME = '9999-12-31T23:59:59.999999+00:00'
+FALLBACK_DATETIME = '9999-12-31T23:59:59.999+00:00'
 
 
 class ReplicationSlotNotFoundError(Exception):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -38,3 +38,59 @@ class TestDbFunctions(unittest.TestCase):
         self.assertEqual(db.selected_value_to_singer_value_impl(True, 'boolean'), True)
         self.assertEqual(db.selected_value_to_singer_value_impl(0, 'boolean'), False)
         self.assertEqual(db.selected_value_to_singer_value_impl(False, 'boolean'), False)
+
+
+    def test_prepare_columns_sql(self):
+        self.assertEqual(' "my_column" ', db.prepare_columns_sql('my_column'))
+
+    def test_prepare_columns_for_select_sql_with_timestamp_ntz_column(self):
+        self.assertEqual(
+            'CASE WHEN  "my_column"  < \'0001-01-01 00:00:00.000000\' OR '
+            ' "my_column"  > \'9999-12-31 23:59:59.999999\' THEN \'9999-12-31 23:59:59.999999\' '
+            'ELSE  "my_column"  END AS  "my_column" ',
+            db.prepare_columns_for_select_sql('my_column',
+                                              {
+                                                  ('properties', 'my_column'):{
+                                                      'sql-datatype': 'timestamp without time zone'
+                                                  }
+                                              }
+                                              )
+        )
+
+    def test_prepare_columns_for_select_sql_with_timestamp_tz_column(self):
+        self.assertEqual(
+            'CASE WHEN  "my_column"  < \'0001-01-01 00:00:00.000000\' OR '
+            ' "my_column"  > \'9999-12-31 23:59:59.999999\' THEN \'9999-12-31 23:59:59.999999\' '
+            'ELSE  "my_column"  END AS  "my_column" ',
+            db.prepare_columns_for_select_sql('my_column',
+                                              {
+                                                  ('properties', 'my_column'):{
+                                                      'sql-datatype': 'timestamp with time zone'
+                                                  }
+                                              }
+                                              )
+        )
+
+    def test_prepare_columns_for_select_sql_with_not_timestamp_column(self):
+        self.assertEqual(
+            ' "my_column" ',
+            db.prepare_columns_for_select_sql('my_column',
+                                              {
+                                                  ('properties', 'my_column'):{
+                                                      'sql-datatype': 'int'
+                                                  }
+                                              }
+                                              )
+        )
+
+    def test_prepare_columns_for_select_sql_with_column_not_in_map(self):
+        self.assertEqual(
+            ' "my_column" ',
+            db.prepare_columns_for_select_sql('my_column',
+                                              {
+                                                  ('properties', 'nope'):{
+                                                      'sql-datatype': 'int'
+                                                  }
+                                              }
+                                              )
+        )

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -46,7 +46,7 @@ class TestDbFunctions(unittest.TestCase):
     def test_prepare_columns_for_select_sql_with_timestamp_ntz_column(self):
         self.assertEqual(
             'CASE WHEN  "my_column"  < \'0001-01-01 00:00:00.000000\' OR '
-            ' "my_column"  > \'9999-12-31 23:59:59.999999\' THEN \'9999-12-31 23:59:59.999999\' '
+            ' "my_column"  > \'9999-12-31 23:59:59.999999\' THEN \'9999-12-31 23:59:59.999\' '
             'ELSE  "my_column"  END AS  "my_column" ',
             db.prepare_columns_for_select_sql('my_column',
                                               {
@@ -60,7 +60,7 @@ class TestDbFunctions(unittest.TestCase):
     def test_prepare_columns_for_select_sql_with_timestamp_tz_column(self):
         self.assertEqual(
             'CASE WHEN  "my_column"  < \'0001-01-01 00:00:00.000000\' OR '
-            ' "my_column"  > \'9999-12-31 23:59:59.999999\' THEN \'9999-12-31 23:59:59.999999\' '
+            ' "my_column"  > \'9999-12-31 23:59:59.999999\' THEN \'9999-12-31 23:59:59.999\' '
             'ELSE  "my_column"  END AS  "my_column" ',
             db.prepare_columns_for_select_sql('my_column',
                                               {

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -45,8 +45,8 @@ class TestDbFunctions(unittest.TestCase):
 
     def test_prepare_columns_for_select_sql_with_timestamp_ntz_column(self):
         self.assertEqual(
-            'CASE WHEN  "my_column"  < \'0001-01-01 00:00:00.000000\' OR '
-            ' "my_column"  > \'9999-12-31 23:59:59.999999\' THEN \'9999-12-31 23:59:59.999\' '
+            'CASE WHEN  "my_column"  < \'0001-01-01 00:00:00.000\' OR '
+            ' "my_column"  > \'9999-12-31 23:59:59.999\' THEN \'9999-12-31 23:59:59.999\' '
             'ELSE  "my_column"  END AS  "my_column" ',
             db.prepare_columns_for_select_sql('my_column',
                                               {
@@ -59,8 +59,8 @@ class TestDbFunctions(unittest.TestCase):
 
     def test_prepare_columns_for_select_sql_with_timestamp_tz_column(self):
         self.assertEqual(
-            'CASE WHEN  "my_column"  < \'0001-01-01 00:00:00.000000\' OR '
-            ' "my_column"  > \'9999-12-31 23:59:59.999999\' THEN \'9999-12-31 23:59:59.999\' '
+            'CASE WHEN  "my_column"  < \'0001-01-01 00:00:00.000\' OR '
+            ' "my_column"  > \'9999-12-31 23:59:59.999\' THEN \'9999-12-31 23:59:59.999\' '
             'ELSE  "my_column"  END AS  "my_column" ',
             db.prepare_columns_for_select_sql('my_column',
                                               {

--- a/tests/test_full_table_interruption.py
+++ b/tests/test_full_table_interruption.py
@@ -130,8 +130,8 @@ class LogicalInterruption(unittest.TestCase):
             'colour': 'brow',
             'id': 2,
             'name': 'smelly',
-            'timestamp_ntz': '9999-12-31T23:59:59.999999+00:00',
-            'timestamp_tz': '9999-12-31T23:59:59.999999+00:00'
+            'timestamp_ntz': '9999-12-31T23:59:59.999000+00:00',
+            'timestamp_tz': '9999-12-31T23:59:59.999000+00:00'
         })
 
         self.assertEqual('public-COW', CAUGHT_MESSAGES[5].stream)
@@ -162,8 +162,8 @@ class LogicalInterruption(unittest.TestCase):
             'colour': 'brow',
             'id': 2,
             'name': 'smelly',
-            'timestamp_ntz': '9999-12-31T23:59:59.999999+00:00',
-            'timestamp_tz': '9999-12-31T23:59:59.999999+00:00'
+            'timestamp_ntz': '9999-12-31T23:59:59.999000+00:00',
+            'timestamp_tz': '9999-12-31T23:59:59.999000+00:00'
         })
 
         self.assertEqual('public-COW', CAUGHT_MESSAGES[2].stream)
@@ -178,8 +178,8 @@ class LogicalInterruption(unittest.TestCase):
             'colour': 'green',
             'id': 3,
             'name': 'pooper',
-            'timestamp_ntz': '9999-12-31T23:59:59.999999+00:00',
-            'timestamp_tz': '9999-12-31T23:59:59.999999+00:00'
+            'timestamp_ntz': '9999-12-31T23:59:59.999000+00:00',
+            'timestamp_tz': '9999-12-31T23:59:59.999000+00:00'
         })
         self.assertEqual('public-COW', CAUGHT_MESSAGES[4].stream)
 

--- a/tests/test_full_table_interruption.py
+++ b/tests/test_full_table_interruption.py
@@ -51,7 +51,10 @@ class LogicalInterruption(unittest.TestCase):
     def setUp(self):
         table_spec_1 = {"columns": [{"name": "id", "type" : "serial",       "primary_key" : True},
                                     {"name" : 'name', "type": "character varying"},
-                                    {"name" : 'colour', "type": "character varying"}],
+                                    {"name" : 'colour', "type": "character varying"},
+                                    {"name" : 'timestamp_ntz', "type": "timestamp without time zone"},
+                                    {"name" : 'timestamp_tz', "type": "timestamp with time zone"},
+                                    ],
                         "name" : 'COW'}
         ensure_test_table(table_spec_1)
         global COW_RECORD_COUNT
@@ -74,22 +77,24 @@ class LogicalInterruption(unittest.TestCase):
             conn.autocommit = True
             cur = conn.cursor()
 
-            cow_rec = {'name' : 'betty', 'colour' : 'blue'}
+            cow_rec = {'name' : 'betty', 'colour' : 'blue',
+                       'timestamp_ntz': '2020-09-01 10:40:59', 'timestamp_tz': '2020-09-01 00:50:59+02'}
             insert_record(cur, 'COW', cow_rec)
 
-            cow_rec = {'name' : 'smelly', 'colour' : 'brow'}
+            cow_rec = {'name' : 'smelly', 'colour' : 'brow',
+                       'timestamp_ntz': '2020-09-01 10:40:59 BC', 'timestamp_tz': '2020-09-01 00:50:59+02 BC'}
             insert_record(cur, 'COW', cow_rec)
 
-            cow_rec = {'name' : 'pooper', 'colour' : 'green'}
+            cow_rec = {'name' : 'pooper', 'colour' : 'green',
+                       'timestamp_ntz': '30000-09-01 10:40:59', 'timestamp_tz': '10000-09-01 00:50:59+02'}
             insert_record(cur, 'COW', cow_rec)
 
         state = {}
         #the initial phase of cows logical replication will be a full table.
         #it will sync the first record and then blow up on the 2nd record
         try:
-
             tap_postgres.do_sync(get_test_connection_config(), {'streams' : streams}, None, state)
-        except Exception as ex:
+        except Exception:
             blew_up_on_cow = True
 
         self.assertTrue(blew_up_on_cow)
@@ -97,30 +102,43 @@ class LogicalInterruption(unittest.TestCase):
         self.assertEqual(7, len(CAUGHT_MESSAGES))
 
         self.assertEqual(CAUGHT_MESSAGES[0]['type'], 'SCHEMA')
-        self.assertTrue(isinstance(CAUGHT_MESSAGES[1], singer.StateMessage))
+        self.assertIsInstance(CAUGHT_MESSAGES[1], singer.StateMessage)
         self.assertIsNone(CAUGHT_MESSAGES[1].value['bookmarks']['public-COW'].get('xmin'))
         self.assertIsNotNone(CAUGHT_MESSAGES[1].value['bookmarks']['public-COW'].get('lsn'))
         end_lsn = CAUGHT_MESSAGES[1].value['bookmarks']['public-COW'].get('lsn')
 
-        self.assertTrue(isinstance(CAUGHT_MESSAGES[2], singer.ActivateVersionMessage))
+        self.assertIsInstance(CAUGHT_MESSAGES[2], singer.ActivateVersionMessage)
         new_version = CAUGHT_MESSAGES[2].version
 
-        self.assertTrue(isinstance(CAUGHT_MESSAGES[3], singer.RecordMessage))
-        self.assertEqual(CAUGHT_MESSAGES[3].record, {'colour': 'blue', 'id': 1, 'name': 'betty'})
+        self.assertIsInstance(CAUGHT_MESSAGES[3], singer.RecordMessage)
+        self.assertEqual(CAUGHT_MESSAGES[3].record, {
+            'colour': 'blue',
+            'id': 1,
+            'name': 'betty',
+            'timestamp_ntz': '2020-09-01T10:40:59+00:00',
+            'timestamp_tz': '2020-08-31T22:50:59+00:00'
+        })
+
         self.assertEqual('public-COW', CAUGHT_MESSAGES[3].stream)
 
-        self.assertTrue(isinstance(CAUGHT_MESSAGES[4], singer.StateMessage))
+        self.assertIsInstance(CAUGHT_MESSAGES[4], singer.StateMessage)
         #xmin is set while we are processing the full table replication
         self.assertIsNotNone(CAUGHT_MESSAGES[4].value['bookmarks']['public-COW']['xmin'])
         self.assertEqual(CAUGHT_MESSAGES[4].value['bookmarks']['public-COW']['lsn'], end_lsn)
 
-        self.assertEqual(CAUGHT_MESSAGES[5].record['name'], 'smelly')
+        self.assertEqual(CAUGHT_MESSAGES[5].record, {
+            'colour': 'brow',
+            'id': 2,
+            'name': 'smelly',
+            'timestamp_ntz': '9999-12-31T23:59:59.999999+00:00',
+            'timestamp_tz': '9999-12-31T23:59:59.999999+00:00'
+        })
+
         self.assertEqual('public-COW', CAUGHT_MESSAGES[5].stream)
 
-        self.assertTrue(isinstance(CAUGHT_MESSAGES[6], singer.StateMessage))
+        self.assertIsInstance(CAUGHT_MESSAGES[6], singer.StateMessage)
         last_xmin = CAUGHT_MESSAGES[6].value['bookmarks']['public-COW']['xmin']
         old_state = CAUGHT_MESSAGES[6].value
-
 
         #run another do_sync, should get the remaining record which effectively finishes the initial full_table
         #replication portion of the logical replication
@@ -134,34 +152,47 @@ class LogicalInterruption(unittest.TestCase):
 
         self.assertEqual(CAUGHT_MESSAGES[0]['type'], 'SCHEMA')
 
-        self.assertTrue(isinstance(CAUGHT_MESSAGES[1], singer.StateMessage))
+        self.assertIsInstance(CAUGHT_MESSAGES[1], singer.StateMessage)
         self.assertEqual(CAUGHT_MESSAGES[1].value['bookmarks']['public-COW'].get('xmin'), last_xmin)
         self.assertEqual(CAUGHT_MESSAGES[1].value['bookmarks']['public-COW'].get('lsn'), end_lsn)
         self.assertEqual(CAUGHT_MESSAGES[1].value['bookmarks']['public-COW'].get('version'), new_version)
 
-        self.assertTrue(isinstance(CAUGHT_MESSAGES[2], singer.RecordMessage))
-        self.assertEqual(CAUGHT_MESSAGES[2].record, {'colour': 'brow', 'id': 2, 'name': 'smelly'})
+        self.assertIsInstance(CAUGHT_MESSAGES[2], singer.RecordMessage)
+        self.assertEqual(CAUGHT_MESSAGES[2].record, {
+            'colour': 'brow',
+            'id': 2,
+            'name': 'smelly',
+            'timestamp_ntz': '9999-12-31T23:59:59.999999+00:00',
+            'timestamp_tz': '9999-12-31T23:59:59.999999+00:00'
+        })
+
         self.assertEqual('public-COW', CAUGHT_MESSAGES[2].stream)
 
-        self.assertTrue(isinstance(CAUGHT_MESSAGES[3], singer.StateMessage))
+        self.assertIsInstance(CAUGHT_MESSAGES[3], singer.StateMessage)
         self.assertTrue(CAUGHT_MESSAGES[3].value['bookmarks']['public-COW'].get('xmin'),last_xmin)
         self.assertEqual(CAUGHT_MESSAGES[3].value['bookmarks']['public-COW'].get('lsn'), end_lsn)
         self.assertEqual(CAUGHT_MESSAGES[3].value['bookmarks']['public-COW'].get('version'), new_version)
 
-        self.assertTrue(isinstance(CAUGHT_MESSAGES[4], singer.RecordMessage))
-        self.assertEqual(CAUGHT_MESSAGES[4].record['name'], 'pooper')
+        self.assertIsInstance(CAUGHT_MESSAGES[4], singer.RecordMessage)
+        self.assertEqual(CAUGHT_MESSAGES[4].record, {
+            'colour': 'green',
+            'id': 3,
+            'name': 'pooper',
+            'timestamp_ntz': '9999-12-31T23:59:59.999999+00:00',
+            'timestamp_tz': '9999-12-31T23:59:59.999999+00:00'
+        })
         self.assertEqual('public-COW', CAUGHT_MESSAGES[4].stream)
 
-        self.assertTrue(isinstance(CAUGHT_MESSAGES[5], singer.StateMessage))
+        self.assertIsInstance(CAUGHT_MESSAGES[5], singer.StateMessage)
         self.assertTrue(CAUGHT_MESSAGES[5].value['bookmarks']['public-COW'].get('xmin') > last_xmin)
         self.assertEqual(CAUGHT_MESSAGES[5].value['bookmarks']['public-COW'].get('lsn'), end_lsn)
         self.assertEqual(CAUGHT_MESSAGES[5].value['bookmarks']['public-COW'].get('version'), new_version)
 
 
-        self.assertTrue(isinstance(CAUGHT_MESSAGES[6], singer.ActivateVersionMessage))
+        self.assertIsInstance(CAUGHT_MESSAGES[6], singer.ActivateVersionMessage)
         self.assertEqual(CAUGHT_MESSAGES[6].version, new_version)
 
-        self.assertTrue(isinstance(CAUGHT_MESSAGES[7], singer.StateMessage))
+        self.assertIsInstance(CAUGHT_MESSAGES[7], singer.StateMessage)
         self.assertIsNone(CAUGHT_MESSAGES[7].value['bookmarks']['public-COW'].get('xmin'))
         self.assertEqual(CAUGHT_MESSAGES[7].value['bookmarks']['public-COW'].get('lsn'), end_lsn)
         self.assertEqual(CAUGHT_MESSAGES[7].value['bookmarks']['public-COW'].get('version'), new_version)
@@ -230,23 +261,23 @@ class FullTableInterruption(unittest.TestCase):
         self.assertEqual(14, len(CAUGHT_MESSAGES))
 
         self.assertEqual(CAUGHT_MESSAGES[0]['type'], 'SCHEMA')
-        self.assertTrue(isinstance(CAUGHT_MESSAGES[1], singer.StateMessage))
+        self.assertIsInstance(CAUGHT_MESSAGES[1], singer.StateMessage)
         self.assertIsNone(CAUGHT_MESSAGES[1].value['bookmarks']['public-CHICKEN'].get('xmin'))
 
-        self.assertTrue(isinstance(CAUGHT_MESSAGES[2], singer.ActivateVersionMessage))
+        self.assertIsInstance(CAUGHT_MESSAGES[2], singer.ActivateVersionMessage)
         new_version = CAUGHT_MESSAGES[2].version
 
-        self.assertTrue(isinstance(CAUGHT_MESSAGES[3], singer.RecordMessage))
+        self.assertIsInstance(CAUGHT_MESSAGES[3], singer.RecordMessage)
         self.assertEqual('public-CHICKEN', CAUGHT_MESSAGES[3].stream)
 
-        self.assertTrue(isinstance(CAUGHT_MESSAGES[4], singer.StateMessage))
+        self.assertIsInstance(CAUGHT_MESSAGES[4], singer.StateMessage)
         #xmin is set while we are processing the full table replication
         self.assertIsNotNone(CAUGHT_MESSAGES[4].value['bookmarks']['public-CHICKEN']['xmin'])
 
-        self.assertTrue(isinstance(CAUGHT_MESSAGES[5], singer.ActivateVersionMessage))
+        self.assertIsInstance(CAUGHT_MESSAGES[5], singer.ActivateVersionMessage)
         self.assertEqual(CAUGHT_MESSAGES[5].version, new_version)
 
-        self.assertTrue(isinstance(CAUGHT_MESSAGES[6], singer.StateMessage))
+        self.assertIsInstance(CAUGHT_MESSAGES[6], singer.StateMessage)
         self.assertEqual(None, singer.get_currently_syncing( CAUGHT_MESSAGES[6].value))
         #xmin is cleared at the end of the full table replication
         self.assertIsNone(CAUGHT_MESSAGES[6].value['bookmarks']['public-CHICKEN']['xmin'])
@@ -256,18 +287,18 @@ class FullTableInterruption(unittest.TestCase):
         self.assertEqual(CAUGHT_MESSAGES[7]['type'], 'SCHEMA')
 
         self.assertEqual("public-COW", CAUGHT_MESSAGES[7]['stream'])
-        self.assertTrue(isinstance(CAUGHT_MESSAGES[8], singer.StateMessage))
+        self.assertIsInstance(CAUGHT_MESSAGES[8], singer.StateMessage)
         self.assertIsNone(CAUGHT_MESSAGES[8].value['bookmarks']['public-COW'].get('xmin'))
         self.assertEqual("public-COW", CAUGHT_MESSAGES[8].value['currently_syncing'])
 
-        self.assertTrue(isinstance(CAUGHT_MESSAGES[9], singer.ActivateVersionMessage))
+        self.assertIsInstance(CAUGHT_MESSAGES[9], singer.ActivateVersionMessage)
         cow_version = CAUGHT_MESSAGES[9].version
-        self.assertTrue(isinstance(CAUGHT_MESSAGES[10], singer.RecordMessage))
+        self.assertIsInstance(CAUGHT_MESSAGES[10], singer.RecordMessage)
 
         self.assertEqual(CAUGHT_MESSAGES[10].record['name'], 'betty')
         self.assertEqual('public-COW', CAUGHT_MESSAGES[10].stream)
 
-        self.assertTrue(isinstance(CAUGHT_MESSAGES[11], singer.StateMessage))
+        self.assertIsInstance(CAUGHT_MESSAGES[11], singer.StateMessage)
         #xmin is set while we are processing the full table replication
         self.assertIsNotNone(CAUGHT_MESSAGES[11].value['bookmarks']['public-COW']['xmin'])
 
@@ -285,38 +316,38 @@ class FullTableInterruption(unittest.TestCase):
         tap_postgres.do_sync(get_test_connection_config(), {'streams' : streams}, None, old_state)
 
         self.assertEqual(CAUGHT_MESSAGES[0]['type'], 'SCHEMA')
-        self.assertTrue(isinstance(CAUGHT_MESSAGES[1], singer.StateMessage))
+        self.assertIsInstance(CAUGHT_MESSAGES[1], singer.StateMessage)
 
         # because we were interrupted, we do not switch versions
         self.assertEqual(CAUGHT_MESSAGES[1].value['bookmarks']['public-COW']['version'], cow_version)
         self.assertIsNotNone(CAUGHT_MESSAGES[1].value['bookmarks']['public-COW']['xmin'])
         self.assertEqual("public-COW", singer.get_currently_syncing(CAUGHT_MESSAGES[1].value))
 
-        self.assertTrue(isinstance(CAUGHT_MESSAGES[2], singer.RecordMessage))
+        self.assertIsInstance(CAUGHT_MESSAGES[2], singer.RecordMessage)
         self.assertEqual(CAUGHT_MESSAGES[2].record['name'], 'smelly')
         self.assertEqual('public-COW', CAUGHT_MESSAGES[2].stream)
 
 
         #after record: activate version, state with no xmin or currently syncing
-        self.assertTrue(isinstance(CAUGHT_MESSAGES[3], singer.StateMessage))
+        self.assertIsInstance(CAUGHT_MESSAGES[3], singer.StateMessage)
         #we still have an xmin for COW because are not yet done with the COW table
         self.assertIsNotNone(CAUGHT_MESSAGES[3].value['bookmarks']['public-COW']['xmin'])
         self.assertEqual(singer.get_currently_syncing( CAUGHT_MESSAGES[3].value), 'public-COW')
 
-        self.assertTrue(isinstance(CAUGHT_MESSAGES[4], singer.RecordMessage))
+        self.assertIsInstance(CAUGHT_MESSAGES[4], singer.RecordMessage)
         self.assertEqual(CAUGHT_MESSAGES[4].record['name'], 'pooper')
         self.assertEqual('public-COW', CAUGHT_MESSAGES[4].stream)
 
-        self.assertTrue(isinstance(CAUGHT_MESSAGES[5], singer.StateMessage))
+        self.assertIsInstance(CAUGHT_MESSAGES[5], singer.StateMessage)
         self.assertIsNotNone(CAUGHT_MESSAGES[5].value['bookmarks']['public-COW']['xmin'])
         self.assertEqual(singer.get_currently_syncing( CAUGHT_MESSAGES[5].value), 'public-COW')
 
 
         #xmin is cleared because we are finished the full table replication
-        self.assertTrue(isinstance(CAUGHT_MESSAGES[6], singer.ActivateVersionMessage))
+        self.assertIsInstance(CAUGHT_MESSAGES[6], singer.ActivateVersionMessage)
         self.assertEqual(CAUGHT_MESSAGES[6].version, cow_version)
 
-        self.assertTrue(isinstance(CAUGHT_MESSAGES[7], singer.StateMessage))
+        self.assertIsInstance(CAUGHT_MESSAGES[7], singer.StateMessage)
         self.assertIsNone(singer.get_currently_syncing( CAUGHT_MESSAGES[7].value))
         self.assertIsNone(CAUGHT_MESSAGES[7].value['bookmarks']['public-CHICKEN']['xmin'])
         self.assertIsNone(singer.get_currently_syncing( CAUGHT_MESSAGES[7].value))

--- a/tests/test_logical_replication.py
+++ b/tests/test_logical_replication.py
@@ -303,6 +303,34 @@ class TestLogicalReplication(unittest.TestCase):
 
         self.assertEqual('9999-12-31T23:59:59.999+00:00', output)
 
+    def test_selected_value_to_singer_value_impl_with_timestamp_ntz_value_as_string_min(self):
+        output = logical_replication.selected_value_to_singer_value_impl('0001-01-01 00:00:00.000123',
+                                                                         'timestamp without time zone',
+                                                                         None)
+
+        self.assertEqual('0001-01-01T00:00:00.000123+00:00', output)
+
+    def test_selected_value_to_singer_value_impl_with_timestamp_ntz_value_as_string_max(self):
+        output = logical_replication.selected_value_to_singer_value_impl('9999-12-31 23:59:59.999999',
+                                                                         'timestamp without time zone',
+                                                                         None)
+
+        self.assertEqual('9999-12-31T23:59:59.999+00:00', output)
+
+    def test_selected_value_to_singer_value_impl_with_timestamp_ntz_value_as_datetime_min(self):
+        output = logical_replication.selected_value_to_singer_value_impl(datetime(1, 1, 1, 0, 0, 0, 123),
+                                                                         'timestamp without time zone',
+                                                                         None)
+
+        self.assertEqual('0001-01-01T00:00:00.000123+00:00', output)
+
+    def test_selected_value_to_singer_value_impl_with_timestamp_ntz_value_as_datetime_max(self):
+        output = logical_replication.selected_value_to_singer_value_impl(datetime(9999, 12, 31, 23, 59, 59, 999999),
+                                                                         'timestamp without time zone',
+                                                                         None)
+
+        self.assertEqual('9999-12-31T23:59:59.999+00:00', output)
+
     def test_selected_value_to_singer_value_impl_with_timestamp_tz_value_as_string_expect_iso_format(self):
         output = logical_replication.selected_value_to_singer_value_impl('2020-09-01 20:10:56+05',
                                                                          'timestamp with time zone',
@@ -361,6 +389,37 @@ class TestLogicalReplication(unittest.TestCase):
                                                                          None)
 
         self.assertEqual('9999-12-31T23:59:59.999+00:00', output)
+
+    def test_selected_value_to_singer_value_impl_with_timestamp_tz_value_as_string_min(self):
+        output = logical_replication.selected_value_to_singer_value_impl('0001-01-01 00:00:00.000123+04',
+                                                                         'timestamp with time zone',
+                                                                         None)
+
+        self.assertEqual('9999-12-31T23:59:59.999+00:00', output)
+
+    def test_selected_value_to_singer_value_impl_with_timestamp_tz_value_as_string_max(self):
+        output = logical_replication.selected_value_to_singer_value_impl('9999-12-31 23:59:59.999999-03',
+                                                                         'timestamp with time zone',
+                                                                         None)
+
+        self.assertEqual('9999-12-31T23:59:59.999+00:00', output)
+
+    def test_selected_value_to_singer_value_impl_with_timestamp_tz_value_as_datetime_min(self):
+        output = logical_replication.selected_value_to_singer_value_impl(datetime(1, 1, 1, 0, 0, 0, 123,
+                                                                                  tzinfo=tzoffset(None, 14400)),
+                                                                         'timestamp with time zone',
+                                                                         None)
+
+        self.assertEqual('9999-12-31T23:59:59.999+00:00', output)
+
+    def test_selected_value_to_singer_value_impl_with_timestamp_tz_value_as_datetime_max(self):
+        output = logical_replication.selected_value_to_singer_value_impl(datetime(9999, 12, 31, 23, 59, 59, 999999,
+                                                                                  tzinfo=tzoffset(None, -14400)),
+                                                                         'timestamp with time zone',
+                                                                         None)
+
+        self.assertEqual('9999-12-31T23:59:59.999+00:00', output)
+
 
     def test_row_to_singer_message(self):
         stream = {

--- a/tests/test_logical_replication.py
+++ b/tests/test_logical_replication.py
@@ -268,7 +268,7 @@ class TestLogicalReplication(unittest.TestCase):
                                                                          'timestamp without time zone',
                                                                          None)
 
-        self.assertEqual('9999-12-31T23:59:59.999999+00:00', output)
+        self.assertEqual('9999-12-31T23:59:59.999+00:00', output)
 
     def test_selected_value_to_singer_value_impl_with_timestamp_ntz_value_as_string_out_of_range_2(self):
         """
@@ -279,7 +279,7 @@ class TestLogicalReplication(unittest.TestCase):
                                                                          'timestamp without time zone',
                                                                          None)
 
-        self.assertEqual('9999-12-31T23:59:59.999999+00:00', output)
+        self.assertEqual('9999-12-31T23:59:59.999+00:00', output)
 
     def test_selected_value_to_singer_value_impl_with_timestamp_ntz_value_as_string_BC(self):
         """
@@ -290,7 +290,7 @@ class TestLogicalReplication(unittest.TestCase):
                                                                          'timestamp without time zone',
                                                                          None)
 
-        self.assertEqual('9999-12-31T23:59:59.999999+00:00', output)
+        self.assertEqual('9999-12-31T23:59:59.999+00:00', output)
 
     def test_selected_value_to_singer_value_impl_with_timestamp_ntz_value_as_string_AC(self):
         """
@@ -301,7 +301,7 @@ class TestLogicalReplication(unittest.TestCase):
                                                                          'timestamp without time zone',
                                                                          None)
 
-        self.assertEqual('9999-12-31T23:59:59.999999+00:00', output)
+        self.assertEqual('9999-12-31T23:59:59.999+00:00', output)
 
     def test_selected_value_to_singer_value_impl_with_timestamp_tz_value_as_string_expect_iso_format(self):
         output = logical_replication.selected_value_to_singer_value_impl('2020-09-01 20:10:56+05',
@@ -327,7 +327,7 @@ class TestLogicalReplication(unittest.TestCase):
                                                                          'timestamp with time zone',
                                                                          None)
 
-        self.assertEqual('9999-12-31T23:59:59.999999+00:00', output)
+        self.assertEqual('9999-12-31T23:59:59.999+00:00', output)
 
     def test_selected_value_to_singer_value_impl_with_timestamp_tz_value_as_string_out_of_range_2(self):
         """
@@ -338,7 +338,7 @@ class TestLogicalReplication(unittest.TestCase):
                                                                          'timestamp with time zone',
                                                                          None)
 
-        self.assertEqual('9999-12-31T23:59:59.999999+00:00', output)
+        self.assertEqual('9999-12-31T23:59:59.999+00:00', output)
 
     def test_selected_value_to_singer_value_impl_with_timestamp_tz_value_as_string_BC(self):
         """
@@ -349,7 +349,7 @@ class TestLogicalReplication(unittest.TestCase):
                                                                          'timestamp with time zone',
                                                                          None)
 
-        self.assertEqual('9999-12-31T23:59:59.999999+00:00', output)
+        self.assertEqual('9999-12-31T23:59:59.999+00:00', output)
 
     def test_selected_value_to_singer_value_impl_with_timestamp_tz_value_as_string_AC(self):
         """
@@ -360,7 +360,7 @@ class TestLogicalReplication(unittest.TestCase):
                                                                          'timestamp with time zone',
                                                                          None)
 
-        self.assertEqual('9999-12-31T23:59:59.999999+00:00', output)
+        self.assertEqual('9999-12-31T23:59:59.999+00:00', output)
 
     def test_row_to_singer_message(self):
         stream = {
@@ -412,12 +412,12 @@ class TestLogicalReplication(unittest.TestCase):
         self.assertEqual('my_schema-my_stream', output.stream)
         self.assertDictEqual({
             'c_timestamp_ntz_1': '2020-01-01T10:30:45+00:00',
-            'c_timestamp_ntz_2': '9999-12-31T23:59:59.999999+00:00',
-            'c_timestamp_ntz_3': '9999-12-31T23:59:59.999999+00:00',
+            'c_timestamp_ntz_2': '9999-12-31T23:59:59.999+00:00',
+            'c_timestamp_ntz_3': '9999-12-31T23:59:59.999+00:00',
             'c_timestamp_ntz_4': '2020-01-01T10:30:45+00:00',
             'c_timestamp_tz_1' : '2020-01-01T10:30:45-02:00',
-            'c_timestamp_tz_2' : '9999-12-31T23:59:59.999999+00:00',
-            'c_timestamp_tz_3' : '9999-12-31T23:59:59.999999+00:00',
+            'c_timestamp_tz_2' : '9999-12-31T23:59:59.999+00:00',
+            'c_timestamp_tz_3' : '9999-12-31T23:59:59.999+00:00',
             'c_timestamp_tz_4' : '2020-01-01T10:30:45+01:00',
         }, output.record)
 

--- a/tests/test_logical_replication.py
+++ b/tests/test_logical_replication.py
@@ -1,8 +1,9 @@
-import json
 import unittest
 
 from collections import namedtuple
+from datetime import datetime
 from unittest.mock import patch
+from dateutil.tz import tzoffset
 
 from tap_postgres.sync_strategies import logical_replication
 from tap_postgres.sync_strategies.logical_replication import UnsupportedPayloadKindError
@@ -73,62 +74,62 @@ class TestLogicalReplication(unittest.TestCase):
         """Validate if the replication slot name generated correctly"""
         # Provide only database name
         self.assertEqual(logical_replication.generate_replication_slot_name('some_db'),
-                          'pipelinewise_some_db')
+                         'pipelinewise_some_db')
 
         # Provide database name and tap_id
         self.assertEqual(logical_replication.generate_replication_slot_name('some_db',
-                                                                             'some_tap'),
-                          'pipelinewise_some_db_some_tap')
+                                                                            'some_tap'),
+                         'pipelinewise_some_db_some_tap')
 
         # Provide database name, tap_id and prefix
         self.assertEqual(logical_replication.generate_replication_slot_name('some_db',
-                                                                             'some_tap',
-                                                                             prefix='custom_prefix'),
-                          'custom_prefix_some_db_some_tap')
+                                                                            'some_tap',
+                                                                            prefix='custom_prefix'),
+                         'custom_prefix_some_db_some_tap')
 
         # Replication slot name should be lowercase
         self.assertEqual(logical_replication.generate_replication_slot_name('SoMe_DB',
-                                                                             'SoMe_TaP'),
-                          'pipelinewise_some_db_some_tap')
+                                                                            'SoMe_TaP'),
+                         'pipelinewise_some_db_some_tap')
 
     def test_locate_replication_slot_by_cur(self):
         """Validate if both v15 and v16 style replication slot located correctly"""
         # Should return v15 style slot name if v15 style replication slot exists
         cursor = PostgresCurReplicationSlotMock(existing_slot_name='pipelinewise_some_db')
         self.assertEqual(logical_replication.locate_replication_slot_by_cur(cursor,
-                                                                             'some_db',
-                                                                             'some_tap'),
-                          'pipelinewise_some_db')
+                                                                            'some_db',
+                                                                            'some_tap'),
+                         'pipelinewise_some_db')
 
         # Should return v16 style slot name if v16 style replication slot exists
         cursor = PostgresCurReplicationSlotMock(existing_slot_name='pipelinewise_some_db_some_tap')
         self.assertEqual(logical_replication.locate_replication_slot_by_cur(cursor,
-                                                                             'some_db',
-                                                                             'some_tap'),
-                          'pipelinewise_some_db_some_tap')
+                                                                            'some_db',
+                                                                            'some_tap'),
+                         'pipelinewise_some_db_some_tap')
 
         # Should return v15 style replication slot if tap_id not provided and the v15 slot exists
         cursor = PostgresCurReplicationSlotMock(existing_slot_name='pipelinewise_some_db')
         self.assertEqual(logical_replication.locate_replication_slot_by_cur(cursor,
-                                                                             'some_db'),
-                          'pipelinewise_some_db')
+                                                                            'some_db'),
+                         'pipelinewise_some_db')
 
         # Should raise an exception if no v15 or v16 style replication slot found
         cursor = PostgresCurReplicationSlotMock(existing_slot_name=None)
         with self.assertRaises(logical_replication.ReplicationSlotNotFoundError):
             self.assertEqual(logical_replication.locate_replication_slot_by_cur(cursor,
-                                                                                 'some_db',
-                                                                                 'some_tap'),
-                              'pipelinewise_some_db_some_tap')
+                                                                                'some_db',
+                                                                                'some_tap'),
+                             'pipelinewise_some_db_some_tap')
 
     def test_consume_with_message_payload_is_not_json_expect_same_state(self):
-
         output = logical_replication.consume_message([],
-                                            {},
-                                            self.WalMessage(payload='this is an invalid json message', data_start=None),
-                                            None,
-                                            {}
-                                            )
+                                                     {},
+                                                     self.WalMessage(payload='this is an invalid json message',
+                                                                     data_start=None),
+                                                     None,
+                                                     {}
+                                                     )
         self.assertDictEqual({}, output)
 
     def test_consume_with_message_stream_in_payload_is_not_selected_expect_same_state(self):
@@ -144,7 +145,6 @@ class TestLogicalReplication(unittest.TestCase):
         self.assertDictEqual({}, output)
 
     def test_consume_with_payload_kind_is_not_supported_expect_exception(self):
-
         with self.assertRaises(UnsupportedPayloadKindError):
             logical_replication.consume_message(
                 [{'tap_stream_id': 'myschema-mytable'}],
@@ -154,6 +154,7 @@ class TestLogicalReplication(unittest.TestCase):
                 None,
                 {}
             )
+
     @patch('tap_postgres.logical_replication.singer.write_message')
     @patch('tap_postgres.logical_replication.sync_common.send_schema_message')
     @patch('tap_postgres.logical_replication.refresh_streams_schema')
@@ -162,48 +163,48 @@ class TestLogicalReplication(unittest.TestCase):
                                                                             send_schema_mock,
                                                                             write_message_mock):
         streams = [
-                {
-                    'tap_stream_id': 'myschema-mytable',
-                    'stream': 'mytable',
-                    'schema': {
-                        'properties': {
-                            'id': {},
-                            'date_created': {}
+            {
+                'tap_stream_id': 'myschema-mytable',
+                'stream': 'mytable',
+                'schema': {
+                    'properties': {
+                        'id': {},
+                        'date_created': {}
+                    }
+                },
+                'metadata': [
+                    {
+                        'breadcrumb': [],
+                        'metadata': {
+                            'is-view': False,
+                            'table-key-properties': ['id'],
+                            'schema-name': 'myschema'
                         }
                     },
-                    'metadata': [
-                        {
-                            'breadcrumb': [],
-                            'metadata': {
-                                'is-view': False,
-                                'table-key-properties': ['id'],
-                                'schema-name': 'myschema'
-                            }
-                        },
-                        {
-                            "breadcrumb": [
-                                "properties",
-                                "id"
-                            ],
-                            "metadata": {
-                                "sql-datatype": "integer",
-                                "inclusion": "automatic",
-                            }
-                        },
-                        {
-                            "breadcrumb": [
-                                "properties",
-                                "date_created"
-                            ],
-                            "metadata": {
-                                "sql-datatype": "datetime",
-                                "inclusion": "available",
-                                "selected": True
-                            }
+                    {
+                        "breadcrumb": [
+                            "properties",
+                            "id"
+                        ],
+                        "metadata": {
+                            "sql-datatype": "integer",
+                            "inclusion": "automatic",
                         }
-                    ],
-                }
-            ]
+                    },
+                    {
+                        "breadcrumb": [
+                            "properties",
+                            "date_created"
+                        ],
+                        "metadata": {
+                            "sql-datatype": "datetime",
+                            "inclusion": "available",
+                            "selected": True
+                        }
+                    }
+                ],
+            }
+        ]
 
         return_v = logical_replication.consume_message(
             streams,
@@ -229,17 +230,196 @@ class TestLogicalReplication(unittest.TestCase):
         )
 
         self.assertDictEqual(return_v,
-                          {
-                              'bookmarks': {
-                                  "myschema-mytable": {
-                                      "last_replication_method": "LOG_BASED",
-                                      "lsn": "some lsn",
-                                      "version": 1000,
-                                      "xmin": None
-                                  }
-                              }
-                          })
+                             {
+                                 'bookmarks': {
+                                     "myschema-mytable": {
+                                         "last_replication_method": "LOG_BASED",
+                                         "lsn": "some lsn",
+                                         "version": 1000,
+                                         "xmin": None
+                                     }
+                                 }
+                             })
 
         refresh_schema_mock.assert_called_once_with({}, [streams[0]])
         send_schema_mock.assert_called_once()
         write_message_mock.assert_called_once()
+
+    def test_selected_value_to_singer_value_impl_with_timestamp_ntz_value_as_string_expect_iso_format(self):
+        output = logical_replication.selected_value_to_singer_value_impl('2020-09-01 20:10:56',
+                                                                         'timestamp without time zone',
+                                                                         None)
+
+        self.assertEqual('2020-09-01T20:10:56+00:00', output)
+
+    def test_selected_value_to_singer_value_impl_with_timestamp_ntz_value_as_datetime_expect_iso_format(self):
+        output = logical_replication.selected_value_to_singer_value_impl(datetime(2020, 9, 1, 20, 10, 59),
+                                                                         'timestamp without time zone',
+                                                                         None)
+
+        self.assertEqual('2020-09-01T20:10:59+00:00', output)
+
+    def test_selected_value_to_singer_value_impl_with_timestamp_ntz_value_as_string_out_of_range_1(self):
+        """
+        Test selected_value_to_singer_value_impl with timestamp without tz as string where year is > 9999
+        should fallback to max datetime allowed
+        """
+        output = logical_replication.selected_value_to_singer_value_impl('10000-09-01 20:10:56',
+                                                                         'timestamp without time zone',
+                                                                         None)
+
+        self.assertEqual('9999-12-31T23:59:59.999999+00:00', output)
+
+    def test_selected_value_to_singer_value_impl_with_timestamp_ntz_value_as_string_out_of_range_2(self):
+        """
+        Test selected_value_to_singer_value_impl with timestamp without tz as string where year is < 0001
+        should fallback to max datetime allowed
+        """
+        output = logical_replication.selected_value_to_singer_value_impl('0000-09-01 20:10:56',
+                                                                         'timestamp without time zone',
+                                                                         None)
+
+        self.assertEqual('9999-12-31T23:59:59.999999+00:00', output)
+
+    def test_selected_value_to_singer_value_impl_with_timestamp_ntz_value_as_string_BC(self):
+        """
+        Test selected_value_to_singer_value_impl with timestamp without tz as string where era is BC
+        should fallback to max datetime allowed
+        """
+        output = logical_replication.selected_value_to_singer_value_impl('1000-09-01 20:10:56 BC',
+                                                                         'timestamp without time zone',
+                                                                         None)
+
+        self.assertEqual('9999-12-31T23:59:59.999999+00:00', output)
+
+    def test_selected_value_to_singer_value_impl_with_timestamp_ntz_value_as_string_AC(self):
+        """
+        Test selected_value_to_singer_value_impl with timestamp without tz as string where era is AC
+        should fallback to max datetime allowed
+        """
+        output = logical_replication.selected_value_to_singer_value_impl('1000-09-01 20:10:56 AC',
+                                                                         'timestamp without time zone',
+                                                                         None)
+
+        self.assertEqual('9999-12-31T23:59:59.999999+00:00', output)
+
+    def test_selected_value_to_singer_value_impl_with_timestamp_tz_value_as_string_expect_iso_format(self):
+        output = logical_replication.selected_value_to_singer_value_impl('2020-09-01 20:10:56+05',
+                                                                         'timestamp with time zone',
+                                                                         None)
+
+        self.assertEqual('2020-09-01T20:10:56+05:00', output)
+
+    def test_selected_value_to_singer_value_impl_with_timestamp_tz_value_as_datetime_expect_iso_format(self):
+        output = logical_replication.selected_value_to_singer_value_impl(datetime(2020, 9, 1, 23, 10, 59,
+                                                                                  tzinfo=tzoffset(None, -3600)),
+                                                                         'timestamp with time zone',
+                                                                         None)
+
+        self.assertEqual('2020-09-01T23:10:59-01:00', output)
+
+    def test_selected_value_to_singer_value_impl_with_timestamp_tz_value_as_string_out_of_range_1(self):
+        """
+        Test selected_value_to_singer_value_impl with timestamp with tz as string where year is > 9999
+        should fallback to max datetime allowed
+        """
+        output = logical_replication.selected_value_to_singer_value_impl('10000-09-01 20:10:56+06',
+                                                                         'timestamp with time zone',
+                                                                         None)
+
+        self.assertEqual('9999-12-31T23:59:59.999999+00:00', output)
+
+    def test_selected_value_to_singer_value_impl_with_timestamp_tz_value_as_string_out_of_range_2(self):
+        """
+        Test selected_value_to_singer_value_impl with timestamp with tz as string where year is < 0001
+        should fallback to max datetime allowed
+        """
+        output = logical_replication.selected_value_to_singer_value_impl('0000-09-01 20:10:56+01',
+                                                                         'timestamp with time zone',
+                                                                         None)
+
+        self.assertEqual('9999-12-31T23:59:59.999999+00:00', output)
+
+    def test_selected_value_to_singer_value_impl_with_timestamp_tz_value_as_string_BC(self):
+        """
+        Test selected_value_to_singer_value_impl with timestamp with tz as string where era is BC
+        should fallback to max datetime allowed
+        """
+        output = logical_replication.selected_value_to_singer_value_impl('1000-09-01 20:10:56+05 BC',
+                                                                         'timestamp with time zone',
+                                                                         None)
+
+        self.assertEqual('9999-12-31T23:59:59.999999+00:00', output)
+
+    def test_selected_value_to_singer_value_impl_with_timestamp_tz_value_as_string_AC(self):
+        """
+        Test selected_value_to_singer_value_impl with timestamp with tz as string where era is AC
+        should fallback to max datetime allowed
+        """
+        output = logical_replication.selected_value_to_singer_value_impl('1000-09-01 20:10:56-09 AC',
+                                                                         'timestamp with time zone',
+                                                                         None)
+
+        self.assertEqual('9999-12-31T23:59:59.999999+00:00', output)
+
+    def test_row_to_singer_message(self):
+        stream = {
+            'stream': 'my_stream',
+        }
+
+        row = [
+            '2020-01-01 10:30:45',
+            '2020-01-01 10:30:45 BC',
+            '50000-01-01 10:30:45',
+            datetime(2020, 1, 1, 10, 30, 45),
+            '2020-01-01 10:30:45-02',
+            '0000-01-01 10:30:45-02',
+            '2020-01-01 10:30:45-02 AC',
+            datetime(2020, 1, 1, 10, 30, 45, tzinfo=tzoffset(None, 3600)),
+        ]
+
+        columns = [
+            'c_timestamp_ntz_1',
+            'c_timestamp_ntz_2',
+            'c_timestamp_ntz_3',
+            'c_timestamp_ntz_4',
+            'c_timestamp_tz_1',
+            'c_timestamp_tz_2',
+            'c_timestamp_tz_3',
+            'c_timestamp_tz_4',
+        ]
+
+        md_map = {
+            (): {'schema-name': 'my_schema'},
+            ('properties', 'c_timestamp_ntz_1'): {'sql-datatype': 'timestamp without time zone'},
+            ('properties', 'c_timestamp_ntz_2'): {'sql-datatype': 'timestamp without time zone'},
+            ('properties', 'c_timestamp_ntz_3'): {'sql-datatype': 'timestamp without time zone'},
+            ('properties', 'c_timestamp_ntz_4'): {'sql-datatype': 'timestamp without time zone'},
+            ('properties', 'c_timestamp_tz_1'): {'sql-datatype': 'timestamp with time zone'},
+            ('properties', 'c_timestamp_tz_2'): {'sql-datatype': 'timestamp with time zone'},
+            ('properties', 'c_timestamp_tz_3'): {'sql-datatype': 'timestamp with time zone'},
+            ('properties', 'c_timestamp_tz_4'): {'sql-datatype': 'timestamp with time zone'},
+        }
+
+        output = logical_replication.row_to_singer_message(stream,
+                                                           row,
+                                                           1000,
+                                                           columns,
+                                                           datetime(2020, 9, 1, 10, 10, 10, tzinfo=tzoffset(None, 0)),
+                                                           md_map,
+                                                           None)
+
+        self.assertEqual('my_schema-my_stream', output.stream)
+        self.assertDictEqual({
+            'c_timestamp_ntz_1': '2020-01-01T10:30:45+00:00',
+            'c_timestamp_ntz_2': '9999-12-31T23:59:59.999999+00:00',
+            'c_timestamp_ntz_3': '9999-12-31T23:59:59.999999+00:00',
+            'c_timestamp_ntz_4': '2020-01-01T10:30:45+00:00',
+            'c_timestamp_tz_1' : '2020-01-01T10:30:45-02:00',
+            'c_timestamp_tz_2' : '9999-12-31T23:59:59.999999+00:00',
+            'c_timestamp_tz_3' : '9999-12-31T23:59:59.999999+00:00',
+            'c_timestamp_tz_4' : '2020-01-01T10:30:45+01:00',
+        }, output.record)
+
+        self.assertEqual(1000, output.version)
+        self.assertEqual(datetime(2020, 9, 1, 10, 10, 10, tzinfo=tzoffset(None, 0)), output.time_extracted)


### PR DESCRIPTION
## Problem

Timestamps, with or without tz, in the source can either have era in them, e.g `BC` , or the year could be in the far far future > `9999`.
All replication methods fail or produce invalid stream when fetching such timestamps.


### Example
Consider the following table
```

CREATE TABLE "order"
(
    id serial primary key,
    cvarchar varchar,
    created_at timestamp default current_timestamp,
    updated_at timestamp with time zone
);
```
#### Case 1: Timestamp with BC era
 
Let's insert this row:
```
insert into "order" (cvarchar, updated_at)
values ('X', '0001-12-31 23:40:28+00 BC')
;
```

Both incremental and full table fail with
```
ValueError: year 0 is out of range
```
#### Case 2: Timestamp with year > 9999

Let's insert this row:
```
insert into "order" (cvarchar, updated_at)
values ('X','15000-12-31 23:40:28+00'')
```

Incremental yield this record stream
```
{"type": "RECORD", "stream": "public-order", "record": {"created_at": "2020-09-02T08:34:21.031100+00:00", "cvarchar": "Y", "id": 13, "updated_at": "9999-12-31T23:40:28+00:00"}, ...etc}
``` 
Notice the `updated_at` field, the year, month and day are not the same as we inserted, instead, `psycopg2` returns this date altered date, but the hour, min and sec are the same. Not sure if we want this behavior.


## Solution

Leverage push down processing in incremental and full table to test the timestamp range and full back to the maximum date allowed and agreed upon `9999-12-31T23:59:59.999+00:00`.

In log based, we have to do such processing in the application code by catching raised error when attempting to parse and fallback to the max timestamp.There is an edge case where parsing is successful when a timestamp with tz has no tz but has the era, e.g `BC`, this era is parsed as the timezone and warning is raised and the resulting record stream is incorrect, the solution is to catch and handle this warning the same way as the parsing error.

## Notes
* Unfortunately, none of the python date libraries can handle dates in `BC` era.
* Having the microseconds in the fallback date `9999-12-31T23:59:59.999+00:00` be only `999` instead of `999999` is a measure to avoid an issue with target snowflake, see [here](https://github.com/snowflakedb/snowflake-connector-python/issues/392)
