### PR TITLE
 [FIX] - Ensure generated Postgres replication slot name is valid

### DIFF
--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -418,8 +418,8 @@ def generate_replication_slot_name(dbname, tap_id=None, prefix='pipelinewise'):
 
     slot_name = f'{prefix}_{dbname}{tap_id}'.lower()
 
-    # Replace invalid characters and truncate to a maximum of 64 characters; required by Postgres
-    return re.sub('[^a-z0-9_]', '_', slot_name)[:64]
+    # Replace invalid characters to ensure replication slot name is in accordance with Postgres spec
+    return re.sub('[^a-z0-9_]', '_', slot_name)
 
 def locate_replication_slot_by_cur(cursor, dbname, tap_id=None):
     slot_name_v15 = generate_replication_slot_name(dbname)

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -4,6 +4,7 @@ import decimal
 import psycopg2
 import copy
 import json
+import re
 import singer
 import singer.metadata as metadata
 
@@ -414,8 +415,11 @@ def generate_replication_slot_name(dbname, tap_id=None, prefix='pipelinewise'):
     # Convert None to empty string
     else:
         tap_id = ''
-    return f'{prefix}_{dbname}{tap_id}'.lower()
 
+    slot_name = f'{prefix}_{dbname}{tap_id}'.lower()
+
+    # Replace invalid characters and truncate to a maximum of 64 characters; required by Postgres
+    return re.sub('[^a-z0-9_]', '_', slot_name)[:64]
 
 def locate_replication_slot_by_cur(cursor, dbname, tap_id=None):
     slot_name_v15 = generate_replication_slot_name(dbname)

--- a/tests/test_logical_replication.py
+++ b/tests/test_logical_replication.py
@@ -100,13 +100,6 @@ class TestLogicalReplication(unittest.TestCase):
                                                                             'some.tap'),
                           'pipelinewise_some_db_some_tap')
 
-        # Replication slot name should be truncated to 64 characters
-        self.assertEqual(
-            logical_replication.generate_replication_slot_name('some_db_with_an_extremely_long_name',
-                                                               'some_tap_with_an_extremely_long_name'),
-             'pipelinewise_some_db_with_an_extremely_long_name_some_tap_with_a'
-        )
-
     def test_locate_replication_slot_by_cur(self):
         """Validate if both v15 and v16 style replication slot located correctly"""
         # Should return v15 style slot name if v15 style replication slot exists

--- a/tests/test_logical_replication.py
+++ b/tests/test_logical_replication.py
@@ -91,6 +91,22 @@ class TestLogicalReplication(unittest.TestCase):
                                                                              'SoMe_TaP'),
                           'pipelinewise_some_db_some_tap')
 
+        # Invalid characters should be replaced by underscores
+        self.assertEqual(logical_replication.generate_replication_slot_name('some-db',
+                                                                            'some-tap'),
+                          'pipelinewise_some_db_some_tap')
+
+        self.assertEqual(logical_replication.generate_replication_slot_name('some.db',
+                                                                            'some.tap'),
+                          'pipelinewise_some_db_some_tap')
+
+        # Replication slot name should be truncated to 64 characters
+        self.assertEqual(
+            logical_replication.generate_replication_slot_name('some_db_with_an_extremely_long_name',
+                                                               'some_tap_with_an_extremely_long_name'),
+             'pipelinewise_some_db_with_an_extremely_long_name_some_tap_with_a'
+        )
+
     def test_locate_replication_slot_by_cur(self):
         """Validate if both v15 and v16 style replication slot located correctly"""
         # Should return v15 style slot name if v15 style replication slot exists


### PR DESCRIPTION
## Context

When using logical replication from a Postgres tap, Pipelinewise generates the name of the Postgres replication slot used from a combination of prefix, database name, and tap name. This does not work if any of the constituent parts contain characters that are not valid in Postgres replication slot names, or if the full generated name is more than 64 characters long.


### Changes

Replace invalid characters with an underscore and truncate the generated name at 64 characters. See https://github.com/transferwise/pipelinewise/issues/529. [A similar PR ](https://github.com/transferwise/pipelinewise/pull/530)has been opened in the main repo for the fast sync.

## Checklist
- [ ] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [X] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
