### PR TITLE
Enable SSL

### DIFF
--- a/tap_postgres/db.py
+++ b/tap_postgres/db.py
@@ -39,23 +39,23 @@ def fully_qualified_table_name(schema, table):
 
 
 def open_connection(conn_config, logical_replication=False):
+    cfg = {
+        'application_name': 'pipelinewise',
+        'host': conn_config['host'],
+        'dbname': conn_config['dbname'],
+        'user': conn_config['user'],
+        'password': conn_config['password'],
+        'port': conn_config['port'],
+        'connect_timeout': 30
+    }
+
+    if conn_config.get('sslmode'):
+        cfg['sslmode'] = conn_config['sslmode']
+
     if logical_replication:
-        conn = psycopg2.connect(application_name='pipelinewise',
-                                host=conn_config['host'],
-                                dbname=conn_config['dbname'],
-                                user=conn_config['user'],
-                                password=conn_config['password'],
-                                port=conn_config['port'],
-                                connection_factory=psycopg2.extras.LogicalReplicationConnection,
-                                connect_timeout=30)
-    else:
-        conn = psycopg2.connect(application_name='pipelinewise',
-                                host=conn_config['host'],
-                                dbname=conn_config['dbname'],
-                                user=conn_config['user'],
-                                password=conn_config['password'],
-                                port=conn_config['port'],
-                                connect_timeout=30)
+        cfg['connection_factory'] = psycopg2.extras.LogicalReplicationConnection
+    
+    conn = psycopg2.connect(**cfg)
 
     return conn
 


### PR DESCRIPTION
## Context

* SSL connections to Postgres are supported but not configured on DB connection.
* This is based on [this upstream tap PR ](https://github.com/singer-io/tap-postgres/pull/80)
* [Slack conversation](https://singer-io.slack.com/archives/CNL7DL597/p1600352090056300?thread_ts=1600346910.052800&cid=CNL7DL597)
* "ssl: true" needs to be added to db_conn in the tap's YAML for this to work

### Changes

* SSL config is now set in db.py's open_connection

## Checklist
- [ ] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
