### PR TITLE
Make pylint happy

### DIFF
--- a/tap_postgres/db.py
+++ b/tap_postgres/db.py
@@ -54,7 +54,7 @@ def open_connection(conn_config, logical_replication=False):
 
     if logical_replication:
         cfg['connection_factory'] = psycopg2.extras.LogicalReplicationConnection
-    
+
     conn = psycopg2.connect(**cfg)
 
     return conn


### PR DESCRIPTION
## Context

CircleCI is currently failing with a pylint error:
```
#!/bin/bash -eo pipefail
. ./virtualenvs/tap-postgres/bin/activate
pylint --rcfile .pylintrc --disable duplicate-code tap_postgres/
************* Module tap_postgres.db
tap_postgres/db.py:57:0: C0303: Trailing whitespace (trailing-whitespace)

-----------------------------------
Your code has been rated at 9.99/10
```

This PR is removing a whitespace.