### PR TITLE
[AP-840][Bug Fix] Parse data in json(b) columns in LOG BASED method 

### DIFF
--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -211,6 +211,13 @@ def selected_value_to_singer_value_impl(elem, og_sql_datatype, conn_info):
 
     if elem is None:
         return elem
+
+    if sql_datatype == 'money':
+        return elem
+
+    if sql_datatype in ['json', 'jsonb']:
+        return json.loads(elem)
+
     if sql_datatype == 'timestamp without time zone':
         if isinstance(elem, datetime.datetime):
             # we don't want a datetime like datetime(9999, 12, 31, 23, 59, 59, 999999) to be returned

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -39,7 +39,6 @@ class TestDbFunctions(unittest.TestCase):
         self.assertEqual(db.selected_value_to_singer_value_impl(0, 'boolean'), False)
         self.assertEqual(db.selected_value_to_singer_value_impl(False, 'boolean'), False)
 
-
     def test_prepare_columns_sql(self):
         self.assertEqual(' "my_column" ', db.prepare_columns_sql('my_column'))
 
@@ -50,7 +49,7 @@ class TestDbFunctions(unittest.TestCase):
             'ELSE  "my_column"  END AS  "my_column" ',
             db.prepare_columns_for_select_sql('my_column',
                                               {
-                                                  ('properties', 'my_column'):{
+                                                  ('properties', 'my_column'): {
                                                       'sql-datatype': 'timestamp without time zone'
                                                   }
                                               }
@@ -64,7 +63,7 @@ class TestDbFunctions(unittest.TestCase):
             'ELSE  "my_column"  END AS  "my_column" ',
             db.prepare_columns_for_select_sql('my_column',
                                               {
-                                                  ('properties', 'my_column'):{
+                                                  ('properties', 'my_column'): {
                                                       'sql-datatype': 'timestamp with time zone'
                                                   }
                                               }
@@ -76,7 +75,7 @@ class TestDbFunctions(unittest.TestCase):
             ' "my_column" ',
             db.prepare_columns_for_select_sql('my_column',
                                               {
-                                                  ('properties', 'my_column'):{
+                                                  ('properties', 'my_column'): {
                                                       'sql-datatype': 'int'
                                                   }
                                               }
@@ -88,9 +87,45 @@ class TestDbFunctions(unittest.TestCase):
             ' "my_column" ',
             db.prepare_columns_for_select_sql('my_column',
                                               {
-                                                  ('properties', 'nope'):{
+                                                  ('properties', 'nope'): {
                                                       'sql-datatype': 'int'
                                                   }
                                               }
                                               )
         )
+
+    def test_selected_value_to_singer_value_impl_with_null_json_returns_None(self):
+        output = db.selected_value_to_singer_value_impl(None, 'json')
+
+        self.assertEqual(None, output)
+
+    def test_selected_value_to_singer_value_impl_with_empty_json_returns_empty_dict(self):
+        output = db.selected_value_to_singer_value_impl('{}', 'json')
+
+        self.assertEqual({}, output)
+
+    def test_selected_value_to_singer_value_impl_with_non_empty_json_returns_equivalent_dict(self):
+        output = db.selected_value_to_singer_value_impl('{"key1": "A", "key2": [{"kk": "yo"}, {}]}', 'json')
+
+        self.assertEqual({
+            'key1': 'A',
+            'key2': [{'kk': 'yo'}, {}]
+        }, output)
+
+    def test_selected_value_to_singer_value_impl_with_null_jsonb_returns_None(self):
+        output = db.selected_value_to_singer_value_impl(None, 'jsonb')
+
+        self.assertEqual(None, output)
+
+    def test_selected_value_to_singer_value_impl_with_empty_jsonb_returns_empty_dict(self):
+        output = db.selected_value_to_singer_value_impl('{}', 'jsonb')
+
+        self.assertEqual({}, output)
+
+    def test_selected_value_to_singer_value_impl_with_non_empty_jsonb_returns_equivalent_dict(self):
+        output = db.selected_value_to_singer_value_impl('{"key1": "A", "key2": [{"kk": "yo"}, {}]}', 'jsonb')
+
+        self.assertEqual({
+            'key1': 'A',
+            'key2': [{'kk': 'yo'}, {}]
+        }, output)

--- a/tests/test_logical_replication.py
+++ b/tests/test_logical_replication.py
@@ -95,11 +95,11 @@ class TestLogicalReplication(unittest.TestCase):
         # Invalid characters should be replaced by underscores
         self.assertEqual(logical_replication.generate_replication_slot_name('some-db',
                                                                             'some-tap'),
-                          'pipelinewise_some_db_some_tap')
+                         'pipelinewise_some_db_some_tap')
 
         self.assertEqual(logical_replication.generate_replication_slot_name('some.db',
                                                                             'some.tap'),
-                          'pipelinewise_some_db_some_tap')
+                         'pipelinewise_some_db_some_tap')
 
     def test_locate_replication_slot_by_cur(self):
         """Validate if both v15 and v16 style replication slot located correctly"""
@@ -429,7 +429,6 @@ class TestLogicalReplication(unittest.TestCase):
 
         self.assertEqual('9999-12-31T23:59:59.999+00:00', output)
 
-
     def test_row_to_singer_message(self):
         stream = {
             'stream': 'my_stream',
@@ -483,11 +482,59 @@ class TestLogicalReplication(unittest.TestCase):
             'c_timestamp_ntz_2': '9999-12-31T23:59:59.999+00:00',
             'c_timestamp_ntz_3': '9999-12-31T23:59:59.999+00:00',
             'c_timestamp_ntz_4': '2020-01-01T10:30:45+00:00',
-            'c_timestamp_tz_1' : '2020-01-01T10:30:45-02:00',
-            'c_timestamp_tz_2' : '9999-12-31T23:59:59.999+00:00',
-            'c_timestamp_tz_3' : '9999-12-31T23:59:59.999+00:00',
-            'c_timestamp_tz_4' : '2020-01-01T10:30:45+01:00',
+            'c_timestamp_tz_1': '2020-01-01T10:30:45-02:00',
+            'c_timestamp_tz_2': '9999-12-31T23:59:59.999+00:00',
+            'c_timestamp_tz_3': '9999-12-31T23:59:59.999+00:00',
+            'c_timestamp_tz_4': '2020-01-01T10:30:45+01:00',
         }, output.record)
 
         self.assertEqual(1000, output.version)
         self.assertEqual(datetime(2020, 9, 1, 10, 10, 10, tzinfo=tzoffset(None, 0)), output.time_extracted)
+
+    def test_selected_value_to_singer_value_impl_with_null_json_returns_None(self):
+        output = logical_replication.selected_value_to_singer_value_impl(None,
+                                                                         'json',
+                                                                         None)
+
+        self.assertEqual(None, output)
+
+    def test_selected_value_to_singer_value_impl_with_empty_json_returns_empty_dict(self):
+        output = logical_replication.selected_value_to_singer_value_impl('{}',
+                                                                         'json',
+                                                                         None)
+
+        self.assertEqual({}, output)
+
+    def test_selected_value_to_singer_value_impl_with_non_empty_json_returns_equivalent_dict(self):
+        output = logical_replication.selected_value_to_singer_value_impl('{"key1": "A", "key2": [{"kk": "yo"}, {}]}',
+                                                                         'json',
+                                                                         None)
+
+        self.assertEqual({
+            'key1': 'A',
+            'key2': [{'kk': 'yo'}, {}]
+        }, output)
+
+    def test_selected_value_to_singer_value_impl_with_null_jsonb_returns_None(self):
+        output = logical_replication.selected_value_to_singer_value_impl(None,
+                                                                         'jsonb',
+                                                                         None)
+
+        self.assertEqual(None, output)
+
+    def test_selected_value_to_singer_value_impl_with_empty_jsonb_returns_empty_dict(self):
+        output = logical_replication.selected_value_to_singer_value_impl('{}',
+                                                                         'jsonb',
+                                                                         None)
+
+        self.assertEqual({}, output)
+
+    def test_selected_value_to_singer_value_impl_with_non_empty_jsonb_returns_equivalent_dict(self):
+        output = logical_replication.selected_value_to_singer_value_impl('{"key1": "A", "key2": [{"kk": "yo"}, {}]}',
+                                                                         'jsonb',
+                                                                         None)
+
+        self.assertEqual({
+            'key1': 'A',
+            'key2': [{'kk': 'yo'}, {}]
+        }, output)


### PR DESCRIPTION
## Problem

Log_Based replication doesn't properly parse data from json(b) column and the streams end up having stringified json data.
This is not in sync with other replication methods that parse json data.  

This is an example of the streams with the issue:

```json
{"type": "SCHEMA", "stream": "public-edgydata", "schema": {"type": "object", "properties": {"cid": {"type": ["integer"], "minimum": -2147483648, "maximum": 2147483647}, "cjson": {"type": ["null", "object", "array"]}, "cjsonb": {"type": ["null", "object", "array"]}, "_sdc_deleted_at": {"type": ["null", "string"], "format": "date-time"}}, "definitions": {"sdc_recursive_integer_array": {"type": ["null", "integer", "array"], "items": {"$ref": "#/definitions/sdc_recursive_integer_array"}}, "sdc_recursive_number_array": {"type": ["null", "number", "array"], "items": {"$ref": "#/definitions/sdc_recursive_number_array"}}, "sdc_recursive_string_array": {"type": ["null", "string", "array"], "items": {"$ref": "#/definitions/sdc_recursive_string_array"}}, "sdc_recursive_boolean_array": {"type": ["null", "boolean", "array"], "items": {"$ref": "#/definitions/sdc_recursive_boolean_array"}}, "sdc_recursive_timestamp_array": {"type": ["null", "string", "array"], "format": "date-time", "items": {"$ref": "#/definitions/sdc_recursive_timestamp_array"}}, "sdc_recursive_object_array": {"type": ["null", "object", "array"], "items": {"$ref": "#/definitions/sdc_recursive_object_array"}}}}, "key_properties": ["cid"], "bookmark_properties": ["lsn"]}
{"type": "RECORD", "stream": "public-edgydata", "record": {"cid": 30, "cjson": null, "cjsonb": null, "cvarchar": "Special Characters: [\"/\\,!@\u00a3$%^&*()]", "_sdc_deleted_at": null}, "version": 1602577344704, "time_extracted": "2020-10-13T09:06:32.293977Z"}
{"type": "RECORD", "stream": "public-edgydata", "record": {"cid": 31, "cjson": "[]", "cjsonb": "[]", "cvarchar": "[]", "_sdc_deleted_at": null}, "version": 1602577344704, "time_extracted": "2020-10-13T09:06:32.293977Z"}
{"type": "RECORD", "stream": "public-edgydata", "record": {"cid": 32, "cjson": "{}", "cjsonb": "{}", "cvarchar": "{}", "_sdc_deleted_at": null}, "version": 1602577344704, "time_extracted": "2020-10-13T09:06:32.293977Z"}
{"type": "RECORD", "stream": "public-edgydata", "record": {"cid": 33, "cjson": "[{}, {}]", "cjsonb": "[{}, {}]", "cvarchar": "[{}, {}]", "_sdc_deleted_at": null}, "version": 1602577344704, "time_extracted": "2020-10-13T09:06:32.293977Z"}
{"type": "RECORD", "stream": "public-edgydata", "record": {"cid": 34, "cjson": "[{\"key\": \"ValueOne\", \"actions\": []}, {\"key\": \"ValueTwo\", \"actions\": []}]", "cjsonb": "[{\"key\": \"ValueOne\", \"actions\": []}, {\"key\": \"ValueTwo\", \"actions\": []}]", "cvarchar": "[{\"key\": \"ValueOne\", \"actions\": []}, {\"key\": \"ValueTwo\", \"actions\": []}]", "_sdc_deleted_at": null}, "version": 1602577344704, "time_extracted": "2020-10-13T09:06:32.293977Z"}
{"type": "RECORD", "stream": "public-edgydata", "record": {"cid": 35, "cjson": "[{\"key\": \"Value's One\", \"actions\": []},{\"key\": \"Value's Two\", \"actions\": []}]", "cjsonb": "[{\"key\": \"Value's One\", \"actions\": []}, {\"key\": \"Value's Two\", \"actions\": []}]", "cvarchar": "[{\"key\": \"Value's One\", \"actions\": []},{\"key\": \"Value's Two\", \"actions\": []}]", "_sdc_deleted_at": null}, "version": 1602577344704, "time_extracted": "2020-10-13T09:06:32.293977Z"}

```

## Proposed changes

Parse data from json(b) when converting a row to a record message in log based replication method.  

Here is the output with the fix:

```json
{"type": "SCHEMA", "stream": "public-edgydata", "schema": {"type": "object", "properties": {"cid": {"type": ["integer"], "minimum": -2147483648, "maximum": 2147483647}, "cjson": {"type": ["null", "object", "array"]}, "cjsonb": {"type": ["null", "object", "array"]}, "cvarchar": {"type": ["null", "string"]}, "_sdc_deleted_at": {"type": ["null", "string"], "format": "date-time"}}, "definitions": {"sdc_recursive_integer_array": {"type": ["null", "integer", "array"], "items": {"$ref": "#/definitions/sdc_recursive_integer_array"}}, "sdc_recursive_number_array": {"type": ["null", "number", "array"], "items": {"$ref": "#/definitions/sdc_recursive_number_array"}}, "sdc_recursive_string_array": {"type": ["null", "string", "array"], "items": {"$ref": "#/definitions/sdc_recursive_string_array"}}, "sdc_recursive_boolean_array": {"type": ["null", "boolean", "array"], "items": {"$ref": "#/definitions/sdc_recursive_boolean_array"}}, "sdc_recursive_timestamp_array": {"type": ["null", "string", "array"], "format": "date-time", "items": {"$ref": "#/definitions/sdc_recursive_timestamp_array"}}, "sdc_recursive_object_array": {"type": ["null", "object", "array"], "items": {"$ref": "#/definitions/sdc_recursive_object_array"}}}}, "key_properties": ["cid"], "bookmark_properties": ["lsn"]}
{"type": "RECORD", "stream": "public-edgydata", "record": {"cid": 30, "cjson": null, "cjsonb": null, "cvarchar": "Special Characters: [\"/\\,!@\u00a3$%^&*()]", "_sdc_deleted_at": null}, "version": 1602577344704, "time_extracted": "2020-10-13T08:53:38.039433Z"}
{"type": "RECORD", "stream": "public-edgydata", "record": {"cid": 31, "cjson": [], "cjsonb": [], "cvarchar": "[]", "_sdc_deleted_at": null}, "version": 1602577344704, "time_extracted": "2020-10-13T08:53:38.039433Z"}
{"type": "RECORD", "stream": "public-edgydata", "record": {"cid": 32, "cjson": {}, "cjsonb": {}, "cvarchar": "{}", "_sdc_deleted_at": null}, "version": 1602577344704, "time_extracted": "2020-10-13T08:53:38.039433Z"}
{"type": "RECORD", "stream": "public-edgydata", "record": {"cid": 33, "cjson": [{}, {}], "cjsonb": [{}, {}], "cvarchar": "[{}, {}]", "_sdc_deleted_at": null}, "version": 1602577344704, "time_extracted": "2020-10-13T08:53:38.039433Z"}
{"type": "RECORD", "stream": "public-edgydata", "record": {"cid": 34, "cjson": [{"key": "ValueOne", "actions": []}, {"key": "ValueTwo", "actions": []}], "cjsonb": [{"key": "ValueOne", "actions": []}, {"key": "ValueTwo", "actions": []}], "cvarchar": "[{\"key\": \"ValueOne\", \"actions\": []}, {\"key\": \"ValueTwo\", \"actions\": []}]", "_sdc_deleted_at": null}, "version": 1602577344704, "time_extracted": "2020-10-13T08:53:38.039433Z"}
{"type": "RECORD", "stream": "public-edgydata", "record": {"cid": 35, "cjson": [{"key": "Value's One", "actions": []}, {"key": "Value's Two", "actions": []}], "cjsonb": [{"key": "Value's One", "actions": []}, {"key": "Value's Two", "actions": []}], "cvarchar": "[{\"key\": \"Value's One\", \"actions\": []},{\"key\": \"Value's Two\", \"actions\": []}]", "_sdc_deleted_at": null}, "version": 1602577344704, "time_extracted": "2020-10-13T08:53:38.039433Z"}
```

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
