### PR TITLE
added statement_timeout to connection_config

### DIFF
--- a/tap_postgres/db.py
+++ b/tap_postgres/db.py
@@ -49,6 +49,9 @@ def open_connection(conn_config, logical_replication=False):
         'connect_timeout': 30
     }
 
+    if conn_config.get('statement_timeout'):
+        cfg['options'] = '-c statement_timeout={}'.format(conn_config['statement_timeout'])
+
     if conn_config.get('sslmode'):
         cfg['sslmode'] = conn_config['sslmode']
 


### PR DESCRIPTION
## Problem

_Getting this error in tap-postgres. psycopg2.errors.QueryCanceled: canceling statement due to statement timeout_

## Proposed changes

_Added statement_timeout in connection config so that if it is provided then the connection will be held for long time._


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
