### PR TITLE
Bump pylint from 2.4.4 to 2.6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(name='pipelinewise-tap-postgres',
       extras_require={
           "test": [
               'pytest==6.2.1',
-              'pylint==2.4.4',
+              'pylint==2.6.0',
               'pytest-cov==2.10.1'
           ]
       },

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -592,7 +592,7 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
                               })
 
     except psycopg2.ProgrammingError as ex:
-        raise Exception("Unable to start replication with logical replication (slot {})".format(ex))
+        raise Exception("Unable to start replication with logical replication (slot {})".format(ex)) from ex
 
     lsn_received_timestamp = datetime.datetime.utcnow()
     poll_timestamp = datetime.datetime.utcnow()


### PR DESCRIPTION
## Problem

Dependabot is about to upgrade pylint 2.4.4 to 2.6.0 in [this PR](https://github.com/transferwise/pipelinewise-tap-postgres/pull/75) but the new pylint gives error:

```
tap_postgres/sync_strategies/logical_replication.py:595:8: W0707: Consider explicitly re-raising using the 'from' keyword (raise-missing-from)
```

## Proposed changes

Bump pylint and fix pylint error

## Types of changes

What types of changes does your code introduce to PipelineWise?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
