### PR TITLE
Update select query to not include last row, this caused duplicate ke…

### DIFF
--- a/tap_postgres/sync_strategies/incremental.py
+++ b/tap_postgres/sync_strategies/incremental.py
@@ -83,7 +83,7 @@ def sync_table(conn_info, stream, state, desired_columns, md_map):
                 if replication_key_value:
                     select_sql = """SELECT {}
                                     FROM {}
-                                    WHERE {} >= '{}'::{}
+                                    WHERE {} > '{}'::{}
                                     ORDER BY {} ASC""".format(','.join(escaped_columns),
                                                               post_db.fully_qualified_table_name(schema_name,
                                                                                                  stream['table_name']),


### PR DESCRIPTION
this caused the duplicated key error when target table has a primary key but original table doesn't have a primary key

so we should ignore it.