### PR TITLE
Keep non-discoverable metadata from the nodes

### DIFF
--- a/tap_postgres/stream_utils.py
+++ b/tap_postgres/stream_utils.py
@@ -90,6 +90,12 @@ def refresh_streams_schema(conn_config: Dict, streams: List[Dict]):
                 if not metadatum['breadcrumb']:
                     meta.update(new_discovery[stream['tap_stream_id']]['metadata'][idx_met]['metadata'])
                     new_discovery[stream['tap_stream_id']]['metadata'][idx_met]['metadata'] = meta
+                elif metadatum['breadcrumb'] in md_map:
+                    # takes discoverable node's metadata from new_discover
+                    # and keeps remaining metadata from the original node (like 'selected')
+                    node_md_map = md_map.get(metadatum['breadcrumb'])
+                    node_md_map.update(metadatum['metadata'])
+                    new_discovery[stream['tap_stream_id']]['metadata'][idx_met]['metadata'] = node_md_map
 
             # 2nd step: now copy all the metadata from the updated new discovery to the original stream
             streams[idx]['metadata'] = copy.deepcopy(new_discovery[stream['tap_stream_id']]['metadata'])

--- a/tests/test_streams_utils.py
+++ b/tests/test_streams_utils.py
@@ -29,7 +29,8 @@ class TestInit(unittest.TestCase):
 								  {"name": '"character-varying_name"', "type": "character varying"},
 								  {"name": '"varchar-name"', "type": "varchar(28)"},
 								  {"name": 'char_name', "type": "char(10)"},
-								  {"name": '"text-name"', "type": "text"}],
+								  {"name": '"text-name"', "type": "text"},
+								  {"name": '"column_to_exclude-name"', "type": "text"}],
 					  "name": self.table_name}
 
 		ensure_test_table(table_spec)
@@ -51,6 +52,10 @@ class TestInit(unittest.TestCase):
 							'table-key-properties': ['some_id'],
 							'row-count': 1000,
 						}
+					},
+					{
+						'breadcrumb': ['properties', 'column_to_exclude-name'],
+						'metadata': {'selected': False}
 					}
 				]
 			}
@@ -75,6 +80,10 @@ class TestInit(unittest.TestCase):
 			('properties', 'character-varying_name'): {'inclusion': 'available',
 													   'sql-datatype': 'character varying',
 													   'selected-by-default': True},
+		    ('properties', 'column_to_exclude-name'): {'inclusion': 'available',
+		                                               'selected': False,
+		                                               'selected-by-default': True,
+		                                               'sql-datatype': 'text'},
 			('properties', 'id'): {'inclusion': 'automatic',
 								   'sql-datatype': 'integer',
 								   'selected-by-default': True},
@@ -94,6 +103,7 @@ class TestInit(unittest.TestCase):
 										 'character-varying_name': {'type': ['null', 'string']},
 										 'varchar-name': {'type': ['null', 'string'], 'maxLength': 28},
 										 'char_name': {'type': ['null', 'string'], 'maxLength': 10},
-										 'text-name': {'type': ['null', 'string']}},
+										 'text-name': {'type': ['null', 'string']},
+										 'column_to_exclude-name': {'type': ['null', 'string']}},
 						  'type': 'object',
 						  'definitions': BASE_RECURSIVE_SCHEMAS}, streams[0].get('schema'))


### PR DESCRIPTION
## Problem

#59 introduced changes to update streams' schemas and metadata before sync. 
`refresh_streams_schema` in stream_utils.py preserves non-discoverable metadata for a stream, but discards field's metadata. So even if a field is excluded with `"selected": false` in a provided catalog the tap still includes it.

## Proposed changes

For all fields in the newly discovered schema keep non-discoverable metadata from the original catalog.
For instance this preserves `selected` key. Later this key is used here https://github.com/transferwise/pipelinewise-tap-postgres/blob/8c4732ee398f6124a616f929c6f85c5499366149/tap_postgres/sync_strategies/common.py#L12 to determine whether a column should by synced or not.

In a nutshell: restores the fields metadata behaviour to the version before #59 .

The risk: this can be a breaking change in cases if a provided catalog has wrong/outdated fields metadata. Examples: 1) fields metadata has wrong keys which are being overwritten with newly discovered schema 2) metadata excludes some fields, but they are still being synced. After the change the excluded columns will not be synced.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

This can be breaking changes in cases if fields metadata is used in a *not* expected way.

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
