### PR TITLE
Update stream metadata for all fields

### DIFF
--- a/tests/test_full_table_interruption.py
+++ b/tests/test_full_table_interruption.py
@@ -99,7 +99,7 @@ class LogicalInterruption(unittest.TestCase):
 
         self.assertTrue(blew_up_on_cow)
 
-        self.assertEqual(7, len(CAUGHT_MESSAGES))
+        self.assertEqual(7, len(CAUGHT_MESSAGES), "Number of Caught Messages")
 
         self.assertEqual(CAUGHT_MESSAGES[0]['type'], 'SCHEMA')
         self.assertIsInstance(CAUGHT_MESSAGES[1], singer.StateMessage)

--- a/tests/test_streams_utils.py
+++ b/tests/test_streams_utils.py
@@ -51,7 +51,14 @@ class TestInit(unittest.TestCase):
 							'table-key-properties': ['some_id'],
 							'row-count': 1000,
 						}
+					},
+					{
+						'breadcrumb': ['properties', 'char_name'],
+						'metadata': {
+							'arbitrary_field_metadata': 'should be preserved'
+						}
 					}
+
 				]
 			}
 		]
@@ -86,7 +93,8 @@ class TestInit(unittest.TestCase):
 										  'selected-by-default': True},
 			('properties', 'char_name'): {'selected-by-default': True,
 										  'inclusion': 'available',
-										  'sql-datatype': 'character'}})
+										  'sql-datatype': 'character',
+										  'arbitrary_field_metadata': 'should be preserved'}})
 
 		self.assertEqual({'properties': {'id': {'type': ['integer'],
 												'maximum': 2147483647,


### PR DESCRIPTION

## Problem

Field Level metadata is being stripped out by the `refresh_streams_schema()` function

## Proposed changes

Previous code discovers schema and then copies only the stream-level metadata into the discovered schema and then replaces the catalog with the result.  

This change updates the provided catalog with the discovered metadata for each field.

Fixes transferwise/pipelinewise-tap-postgres#101

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ x] Description above provides context of the change
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] Unit tests for changes (not needed for documentation changes)
- [ x] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
