### PR TITLE
https://github.com/transferwise/pipelinewise-tap-postgres/issues/113

### DIFF
--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -56,7 +56,7 @@ def do_sync_full_table(conn_config, stream, state, desired_columns, md_map):
     """
     LOGGER.info("Stream %s is using full_table replication", stream['tap_stream_id'])
     sync_common.send_schema_message(stream, [])
-    attemp = 0
+    attempt = 0
     while True:
         try:
             if md_map.get((), {}).get('is-view'):
@@ -66,10 +66,10 @@ def do_sync_full_table(conn_config, stream, state, desired_columns, md_map):
             return state
         except Exception as e:
             LOGGER.warn("error on read for a stream: %s. Message: %s", stream['tap_stream_id'], e)
-            if attemp > post_db.TRY_NUMBER:
+            if attempt > post_db.TRY_NUMBER:
                 raise e
             else:
-                attemp = attemp + 1
+                attempt = attempt + 1
 
 
 # Possible state keys: replication_key, replication_key_value, version

--- a/tap_postgres/db.py
+++ b/tap_postgres/db.py
@@ -14,6 +14,7 @@ from dateutil.parser import parse
 LOGGER = singer.get_logger('tap_postgres')
 
 CURSOR_ITER_SIZE = 20000
+TRY_NUMBER = 10
 
 
 # pylint: disable=invalid-name,missing-function-docstring


### PR DESCRIPTION
Tap is frequently used to pull data from the postgres replica and a common issue in this case is "canceling statement due to conflict with recovery" especially for a full table sync. It happens when WAL comes to a replica (upon sync between master and a slave). The tap already has a mechanism to resume but no retry mechanism.
I think it would be helpful to be able to configure number of attempts a tap tries to pull the data.