### PR TITLE
Avoid processing timestamp arrays as timestamps

### DIFF
--- a/tap_postgres/db.py
+++ b/tap_postgres/db.py
@@ -62,12 +62,14 @@ def open_connection(conn_config, logical_replication=False):
 def prepare_columns_for_select_sql(c, md_map):
     column_name = ' "{}" '.format(canonicalize_identifier(c))
 
-    if ('properties', c) in md_map and md_map[('properties', c)]['sql-datatype'].startswith('timestamp'):
-        return f'CASE ' \
-               f'WHEN {column_name} < \'0001-01-01 00:00:00.000\' ' \
-               f'OR {column_name} > \'9999-12-31 23:59:59.999\' THEN \'9999-12-31 23:59:59.999\' ' \
-               f'ELSE {column_name} ' \
-               f'END AS {column_name}'
+    if ('properties', c) in md_map:
+        sql_datatype = md_map[('properties', c)]['sql-datatype']
+        if sql_datatype.startswith('timestamp') and not sql_datatype.endswith('[]'):
+            return f'CASE ' \
+                   f'WHEN {column_name} < \'0001-01-01 00:00:00.000\' ' \
+                   f'OR {column_name} > \'9999-12-31 23:59:59.999\' THEN \'9999-12-31 23:59:59.999\' ' \
+                   f'ELSE {column_name} ' \
+                   f'END AS {column_name}'
     return column_name
 
 def prepare_columns_sql(c):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -70,6 +70,30 @@ class TestDbFunctions(unittest.TestCase):
                                               )
         )
 
+    def test_prepare_columns_for_select_sql_with_timestamp_ntz_array_column(self):
+        self.assertEqual(
+            ' "my_column" ',
+            db.prepare_columns_for_select_sql('my_column',
+                                              {
+                                                  ('properties', 'my_column'): {
+                                                      'sql-datatype': 'timestamp without time zone[]'
+                                                  }
+                                              }
+                                              )
+        )
+
+    def test_prepare_columns_for_select_sql_with_timestamp_tz_array_column(self):
+        self.assertEqual(
+            ' "my_column" ',
+            db.prepare_columns_for_select_sql('my_column',
+                                              {
+                                                  ('properties', 'my_column'): {
+                                                      'sql-datatype': 'timestamp with time zone[]'
+                                                  }
+                                              }
+                                              )
+        )
+
     def test_prepare_columns_for_select_sql_with_not_timestamp_column(self):
         self.assertEqual(
             ' "my_column" ',


### PR DESCRIPTION
## Problem

The code that put bounds on timestamps wrongly treats timestamp arrays
as timestamps and crashes.

## Proposed changes

This change excludes arrays from that behaviour, though we should probably
also bound the timestamps inside the array in the same way.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
