### PR TITLE
Handle dates with year > 9999

### DIFF
--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -21,6 +21,7 @@ LOGGER = singer.get_logger('tap_postgres')
 
 UPDATE_BOOKMARK_PERIOD = 10000
 FALLBACK_DATETIME = '9999-12-31T23:59:59.999+00:00'
+FALLBACK_DATE = '9999-12-31T00:00:00.000+00:00'
 
 
 class ReplicationSlotNotFoundError(Exception):
@@ -286,7 +287,15 @@ def selected_value_to_singer_value_impl(elem, og_sql_datatype, conn_info):
         if isinstance(elem, datetime.date):
             # logical replication gives us dates as strings UNLESS they from an array
             return elem.isoformat() + 'T00:00:00+00:00'
-        return parse(elem).isoformat() + "+00:00"
+        try:
+            return parse(elem).isoformat() + "+00:00"
+        except ValueError as e:
+            match = re.match(r'year (\d+) is out of range', str(e))
+            if match and int(match.group(1)) > 9999:
+                LOGGER.warning('datetimes cannot handle years past 9999, returning %s for %s',
+                               FALLBACK_DATE, elem)
+                return FALLBACK_DATE
+            raise
     if sql_datatype == 'time with time zone':
         # time with time zone values will be converted to UTC and time zone dropped
         # Replace hour=24 with hour=0


### PR DESCRIPTION
## Problem

Fixes https://github.com/transferwise/pipelinewise-tap-postgres/issues/119 (exception thrown if date column value has a date with year > 9999). 

## Proposed changes

Set any date past 9999-12-31 to 9999-12-31 and log a warning message.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
