### PR TITLE
Add docker-compose file to make it easy to test against postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,14 @@ to the tap for the next sync.
   export TAP_POSTGRES_PASSWORD=<postgres-password>
 ```
 
+Alternatively, run `docker-compose --file docker-compose-postgres.yml up` to run postgres in a Docker container. The environment variables will be:
+```
+  export TAP_POSTGRES_HOST="127.0.0.1"
+  export TAP_POSTGRES_PORT="5432"
+  export TAP_POSTGRES_USER="dbuser"
+  export TAP_POSTGRES_PASSWORD="admin2021"
+```
+
 Test objects will be created in the `postgres` database.
 
 3. To run the tests:

--- a/docker-compose-postgres.yml
+++ b/docker-compose-postgres.yml
@@ -1,0 +1,9 @@
+version: "3.8"
+services:
+  db:
+    image: "postgres:12"
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=dbuser
+      - POSTGRES_PASSWORD=admin2021


### PR DESCRIPTION
## Problem

I noticed in the README that there are manual instructions for testing against Postgres.

## Proposed changes

This PR adds a docker-compose file (and documentation) for running Postgres in a Docker container, so that make test can be easily run.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
