### PR TITLE
Remove `max_run_seconds` dependency on msg

### DIFF
--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -617,7 +617,7 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
         if datetime.datetime.utcnow() >= (start_run_timestamp + datetime.timedelta(seconds=max_run_seconds)):
             LOGGER.info('Breaking - reached max_run_seconds of %i', max_run_seconds)
             break
-            
+
         try:
             msg = cur.read_message()
         except Exception as e:

--- a/tap_postgres/sync_strategies/logical_replication.py
+++ b/tap_postgres/sync_strategies/logical_replication.py
@@ -614,6 +614,10 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
             LOGGER.info('Breaking - %i seconds of polling with no data', poll_duration)
             break
 
+        if datetime.datetime.utcnow() >= (start_run_timestamp + datetime.timedelta(seconds=max_run_seconds)):
+            LOGGER.info('Breaking - reached max_run_seconds of %i', max_run_seconds)
+            break
+            
         try:
             msg = cur.read_message()
         except Exception as e:
@@ -625,10 +629,6 @@ def sync_tables(conn_info, logical_streams, state, end_lsn, state_file):
                 LOGGER.info('Breaking - latest wal message %s is past end_lsn %s',
                             int_to_lsn(msg.data_start),
                             int_to_lsn(end_lsn))
-                break
-
-            if datetime.datetime.utcnow() >= (start_run_timestamp + datetime.timedelta(seconds=max_run_seconds)):
-                LOGGER.info('Breaking - reached max_run_seconds of %i', max_run_seconds)
                 break
 
             state = consume_message(logical_streams, state, msg, time_extracted, conn_info)


### PR DESCRIPTION
## Problem

See https://github.com/transferwise/pipelinewise-tap-postgres/issues/133

## Proposed changes

`max_run_seconds` does not work as intended because it is wrapped within another contradictory condition.


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [X] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
