### PR TITLE
AP-1207 - abort query on tap termination

### DIFF
--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -6,6 +6,7 @@ import psycopg2.extras
 import psycopg2.extensions
 import singer
 import singer.schema
+import signal
 
 from singer import utils, metadata, get_bookmark
 from singer.catalog import Catalog
@@ -20,6 +21,20 @@ from tap_postgres.discovery_utils import discover_db
 from tap_postgres.stream_utils import (
     dump_catalog, clear_state_on_replication_change,
     is_selected_via_metadata, refresh_streams_schema, any_logical_streams)
+
+
+psycopg2.extensions.set_wait_callback(psycopg2.extras.wait_select)
+
+
+def handle_signal(sig=None, frame=None):
+    """
+    signal handler for sigterms
+    raise sigint because that's how psycopg2 aborts running queries
+    """
+    raise KeyboardInterrupt("RECEIVED SIGTERM. RAISING SIGINT TO ABORT POSTGRES QUERY")
+
+
+signal.signal(signal.SIGTERM, handle_signal)
 
 LOGGER = singer.get_logger('tap_postgres')
 


### PR DESCRIPTION
## Problem

tap-postgres doesn't abort the running query when the tap is terminated

## Proposed changes

add signal handler to abort the running query when the tap is terminated


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
