### PR TITLE
Replace deprecated `--properties` by `--catalog`

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ for more information.
 ### Run the tap in Sync Mode
 
 ```
-tap-postgres --config config.json --properties catalog.json
+tap-postgres --config config.json --catalog catalog.json
 ```
 
 The tap will write bookmarks to stdout which can be captured and passed as an optional `--state state.json` parameter


### PR DESCRIPTION
`tap-postgres -h` says `--properties` is DEPRECATED, hence switch to `--catalog`.

Looks like `--properties` was deprecated right when it was introduced, see #23.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
