### PR TITLE
Recommend `--catalog` instead of `--properties`

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ for more information.
 ### Run the tap in Sync Mode
 
 ```
-tap-postgres --config config.json --properties catalog.json
+tap-postgres --config config.json --catalog catalog.json
 ```
 
 The tap will write bookmarks to stdout which can be captured and passed as an optional `--state state.json` parameter


### PR DESCRIPTION


## Problem

Based on https://github.com/transferwise/pipelinewise-tap-postgres/blob/14a0be55e8494f7f5b7ee4e6627ece902db6729a/tap_postgres/__init__.py#L380-L382 it seems like the tap supports both. Since `--properties` is technically the older and "deprecated" way to pass in the catalog it seems prudent to recommend using `--catalog` in the readme.


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
