### PR TITLE
Wrap INCREMENTAL query in a SELECT * sub-query to speed up data retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+1.8.4 (2022-09-08)
+-------------------
+**Changes**
+- INCREMENTAL: Use sub-query to trick PostreSQL into more efficient use of index.
+
 1.8.3 (2022-01-18)
 -------------------
 **Fixes**
@@ -48,7 +53,7 @@
 Fix data loss issue when running `LOG_BASED` due to the tap not sending new SCHEMA singer messages when source tables change structure, mainly new/renamed columns, which causes the target to not be up to date with the stream structure.
 The tap now:
 * Runs discovery for selected stream at the beginning of sync to send up to date SCHEMA singer messages
-* When new columns are detected in WAL payloads, then run discovery for the stream and send new SCHEMA message. 
+* When new columns are detected in WAL payloads, then run discovery for the stream and send new SCHEMA message.
 
 1.6.2 (2020-05-18)
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
     long_description = f.read()
 
 setup(name='pipelinewise-tap-postgres',
-      version='1.8.3',
+      version='1.8.4',
       description='Singer.io tap for extracting data from PostgresSQL - PipelineWise compatible',
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/tap_postgres/sync_strategies/incremental.py
+++ b/tap_postgres/sync_strategies/incremental.py
@@ -129,13 +129,17 @@ def _get_select_sql(params):
     stream = params['stream']
     if replication_key_value:
         select_sql = f"""
-    SELECT {','.join(escaped_columns)}
-    FROM {post_db.fully_qualified_table_name(schema_name, stream['table_name'])}
-    WHERE {post_db.prepare_columns_sql(replication_key)} >= '{replication_key_value}'::{replication_key_sql_datatype}
-    ORDER BY {post_db.prepare_columns_sql(replication_key)} ASC"""
+        SELECT {','.join(escaped_columns)}
+        FROM (
+            SELECT *
+            FROM {post_db.fully_qualified_table_name(schema_name, stream['table_name'])}
+            WHERE {post_db.prepare_columns_sql(replication_key)} >= '{replication_key_value}'::{replication_key_sql_datatype}
+            ORDER BY {post_db.prepare_columns_sql(replication_key)} ASC
+        ) pg_speedup_trick"""
     else:
         # if not replication_key_value
-        select_sql = f"""SELECT {','.join(escaped_columns)}
-                                    FROM {post_db.fully_qualified_table_name(schema_name, stream['table_name'])}
-                                    ORDER BY {post_db.prepare_columns_sql(replication_key)} ASC"""
+        select_sql = f"""
+        SELECT {','.join(escaped_columns)}
+        FROM {post_db.fully_qualified_table_name(schema_name, stream['table_name'])}
+        """
     return select_sql


### PR DESCRIPTION
## Problem
PostgreSQL does not make efficient use of _datetime_ index only scans when performing a large select as done by the INCREMENTAL replication method

## Proposed changes
Wrap INCREMENTAL query in a SELECT * sub-query to speed up data retrieval

So instead of
```
SELECT  "colour" , "id" , "name"
    FROM "public"."COW"
    WHERE  "id"  >= '3'::integer
    ORDER BY  "id"  ASC
```
use
```
  SELECT  "colour" , "id" , "name" 
  FROM (
      SELECT *
      FROM "public"."COW"
      WHERE  "id"  >= '3'::integer
      ORDER BY  "id"  ASC
  ) pg_speedup_trick
```

this will significantly speed up queries on _datetime_ indexes, but queries on _int_ columns are not negatively impacted


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
