### PR TITLE
Enforce ordering by replication key during full refresh

### DIFF
--- a/tap_postgres/sync_strategies/incremental.py
+++ b/tap_postgres/sync_strategies/incremental.py
@@ -141,5 +141,6 @@ def _get_select_sql(params):
         select_sql = f"""
         SELECT {','.join(escaped_columns)}
         FROM {post_db.fully_qualified_table_name(schema_name, stream['table_name'])}
+        ORDER BY {post_db.prepare_columns_sql(replication_key)} ASC
         """
     return select_sql


### PR DESCRIPTION
## Problem

For the incremental strategy if we stop an initial data load midway our state will be that of the last record that was written to the target. Right now the generated SQL for this case does not enforce ordering records by the replication_key. If we don't enforce the ordering of the records from the source we have no guarantee that all records before the last one were written to the target (as Postgres might return them in disorder).

## Proposed changes

 To overcome these issues we should enforce ordering.


## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
