### PR TITLE
AP-1424: limit config to mitigate long running incremental queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,25 +50,26 @@ These are the same basic configuration properties used by the PostgreSQL command
 
 Full list of options in `config.json`:
 
-| Property                            | Type    | Required?  | Description                                                   |
-|-------------------------------------|---------|------------|---------------------------------------------------------------|
-| host                                | String  | Yes        | PostgreSQL host                                               |
-| port                                | Integer | Yes        | PostgreSQL port                                               |
-| user                                | String  | Yes        | PostgreSQL user                                               |
-| password                            | String  | Yes        | PostgreSQL password                                           |
-| dbname                              | String  | Yes        | PostgreSQL database name                                      |
-| filter_schemas                      | String  | No         | Comma separated schema names to scan only the required schemas to improve the performance of data extraction. (Default: None) |
-| ssl                                 | String  | No         | If set to `"true"` then use SSL via postgres sslmode `require` option. If the server does not accept SSL connections or the client certificate is not recognized the connection will fail. (Default: None) |
-| logical_poll_total_seconds          | Integer | No         | Stop running the tap when no data received from wal after certain number of seconds. (Default: 10800) |
-| break_at_end_lsn                    | Boolean | No         | Stop running the tap if the newly received lsn is after the max lsn that was detected when the tap started. (Default: true) |
-| max_run_seconds                     | Integer | No         | Stop running the tap after certain number of seconds. (Default: 43200) |
-| debug_lsn                           | String  | No         | If set to `"true"` then add `_sdc_lsn` property to the singer messages to debug postgres LSN position in the WAL stream. (Default: None) |
-| tap_id                              | String  | No         | ID of the pipeline/tap (Default: None) |
-| itersize                            | Integer | No         | Size of PG cursor iterator when doing INCREMENTAL or FULL_TABLE  (Default: 20000) |
-| default_replication_method          | String  | No         | Default replication method to use when no one is provided in the catalog (Values: `LOG_BASED`, `INCREMENTAL` or `FULL_TABLE`)  (Default: None) |
-| use_secondary                       | Boolean | No         | Use a database replica for `INCREMENTAL` and `FULL_TABLE` replication (Default : False) |
-| secondary_host                      | String  | No         | PostgreSQL Replica host (required if `use_secondary` is `True`) |
-| secondary_port                      | Integer | No         | PostgreSQL Replica port (required if `use_secondary` is `True`) |
+| Property                   | Type    | Required? | Default | Description                                                                                                                                                                                |
+|----------------------------|---------|----------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| host                       | String  | Yes      | -       | PostgreSQL host                                                                                                                                                                            |
+| port                       | Integer | Yes      | -       | PostgreSQL port                                                                                                                                                                            |
+| user                       | String  | Yes      | -       | PostgreSQL user                                                                                                                                                                            |
+| password                   | String  | Yes      | -       | PostgreSQL password                                                                                                                                                                        |
+| dbname                     | String  | Yes      | -       | PostgreSQL database name                                                                                                                                                                   |
+| filter_schemas             | String  | No       | None    | Comma separated schema names to scan only the required schemas to improve the performance of data extraction.                                                                              |
+| ssl                        | String  | No       | None    | If set to `"true"` then use SSL via postgres sslmode `require` option. If the server does not accept SSL connections or the client certificate is not recognized the connection will fail. |
+| logical_poll_total_seconds | Integer | No       | 10800   | Stop running the tap when no data received from wal after certain number of seconds.                                                                                                       |
+| break_at_end_lsn           | Boolean | No       | true    | Stop running the tap if the newly received lsn is after the max lsn that was detected when the tap started.                                                                                |
+| max_run_seconds            | Integer | No       | 43200   | Stop running the tap after certain number of seconds.                                                                                                                                      |
+| debug_lsn                  | String  | No       | None    | If set to `"true"` then add `_sdc_lsn` property to the singer messages to debug postgres LSN position in the WAL stream.                                                                   |
+| tap_id                     | String  | No       | None    | ID of the pipeline/tap                                                                                                                                                                     |
+| itersize                   | Integer | No       | 20000   | Size of PG cursor iterator when doing INCREMENTAL or FULL_TABLE                                                                                                                            |
+| default_replication_method | String  | No       | None    | Default replication method to use when no one is provided in the catalog (Values: `LOG_BASED`, `INCREMENTAL` or `FULL_TABLE`)                                                              |
+| use_secondary              | Boolean | No       | False   | Use a database replica for `INCREMENTAL` and `FULL_TABLE` replication                                                                                                                      |
+| secondary_host             | String  | No       | -       | PostgreSQL Replica host (required if `use_secondary` is `True`)                                                                                                                            |
+| secondary_port             | Integer | No       | -       | PostgreSQL Replica port (required if `use_secondary` is `True`)                                                                                                                            |
+| limit                      | Integer | No       | None    | Adds a limit to INCREMENTAL queries to limit the number of records returns per run                                                                                                         |
 
 
 ### Run the tap in Discovery Mode

--- a/tap_postgres/__init__.py
+++ b/tap_postgres/__init__.py
@@ -391,6 +391,8 @@ def main_impl():
     Main method
     """
     args = parse_args(REQUIRED_CONFIG_KEYS)
+
+    limit = args.config.get('limit')
     conn_config = {
         # Required config keys
         'host': args.config['host'],
@@ -407,6 +409,7 @@ def main_impl():
         'break_at_end_lsn': args.config.get('break_at_end_lsn', True),
         'logical_poll_total_seconds': float(args.config.get('logical_poll_total_seconds', 0)),
         'use_secondary': args.config.get('use_secondary', False),
+        'limit': int(limit) if limit else None
     }
 
     if conn_config['use_secondary']:

--- a/tap_postgres/sync_strategies/incremental.py
+++ b/tap_postgres/sync_strategies/incremental.py
@@ -130,21 +130,16 @@ def _get_select_sql(params):
     table_name = params['table_name']
 
     limit_statement = f'LIMIT {params["limit"]}' if params["limit"] else ''
+    where_statement = f"WHERE {replication_key} >= '{replication_key_value}'::{replication_key_sql_datatype}" \
+        if replication_key_value else ""
 
-    if replication_key_value:
-        select_sql = f"""
-        SELECT {','.join(escaped_columns)}
-        FROM (
-            SELECT *
-            FROM {post_db.fully_qualified_table_name(schema_name, table_name)}
-            WHERE {replication_key} >= '{replication_key_value}'::{replication_key_sql_datatype}
-            ORDER BY {replication_key} ASC {limit_statement}
-        ) pg_speedup_trick;"""
-    else:
-        # if not replication_key_value
-        select_sql = f"""
-        SELECT {','.join(escaped_columns)}
-        FROM {post_db.fully_qualified_table_name(schema_name, table_name)}
+    select_sql = f"""
+    SELECT {','.join(escaped_columns)}
+    FROM (
+        SELECT *
+        FROM {post_db.fully_qualified_table_name(schema_name, table_name)} 
+        {where_statement}
         ORDER BY {replication_key} ASC {limit_statement}
-        """
+    ) pg_speedup_trick;"""
+
     return select_sql

--- a/tap_postgres/sync_strategies/incremental.py
+++ b/tap_postgres/sync_strategies/incremental.py
@@ -86,7 +86,9 @@ def sync_table(conn_info, stream, state, desired_columns, md_map):
                                               "replication_key_sql_datatype": replication_key_sql_datatype,
                                               "replication_key_value": replication_key_value,
                                               "schema_name": schema_name,
-                                              "stream": stream})
+                                              "table_name": stream['table_name'],
+                                              "limit": conn_info['limit']
+                                              })
                 LOGGER.info('select statement: %s with itersize %s', select_sql, cur.itersize)
                 cur.execute(select_sql)
 
@@ -111,7 +113,6 @@ def sync_table(conn_info, stream, state, desired_columns, md_map):
                                                       'replication_key_value',
                                                       record_message.record[replication_key])
 
-
                     if rows_saved % UPDATE_BOOKMARK_PERIOD == 0:
                         singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
 
@@ -122,24 +123,27 @@ def sync_table(conn_info, stream, state, desired_columns, md_map):
 
 def _get_select_sql(params):
     escaped_columns = params['escaped_columns']
-    replication_key = params['replication_key']
+    replication_key = post_db.prepare_columns_sql(params['replication_key'])
     replication_key_sql_datatype = params['replication_key_sql_datatype']
     replication_key_value = params['replication_key_value']
     schema_name = params['schema_name']
-    stream = params['stream']
+    table_name = params['table_name']
+
+    limit_statement = f'LIMIT {params["limit"]}' if params["limit"] else ''
+
     if replication_key_value:
         select_sql = f"""
         SELECT {','.join(escaped_columns)}
         FROM (
             SELECT *
-            FROM {post_db.fully_qualified_table_name(schema_name, stream['table_name'])}
-            WHERE {post_db.prepare_columns_sql(replication_key)} >= '{replication_key_value}'::{replication_key_sql_datatype}
-            ORDER BY {post_db.prepare_columns_sql(replication_key)} ASC
-        ) pg_speedup_trick"""
+            FROM {post_db.fully_qualified_table_name(schema_name, table_name)}
+            WHERE {replication_key} >= '{replication_key_value}'::{replication_key_sql_datatype}
+            ORDER BY {replication_key} ASC {limit_statement}
+        ) pg_speedup_trick;"""
     else:
         # if not replication_key_value
         select_sql = f"""
         SELECT {','.join(escaped_columns)}
-        FROM {post_db.fully_qualified_table_name(schema_name, stream['table_name'])}
+        FROM {post_db.fully_qualified_table_name(schema_name, table_name)}
         """
     return select_sql

--- a/tests/unit/test_incremental.py
+++ b/tests/unit/test_incremental.py
@@ -29,7 +29,8 @@ class TestIncremental(TestCase):
             'user': 'foo_user',
             'password': 'foo_pass',
             'port': 12345,
-            'use_secondary': False
+            'use_secondary': False,
+            'limit': None
         }
         self.stream = {'tap_stream_id': 5, 'stream': 'bar', 'table_name': 'pg_tbl'}
         self.md_map = {


### PR DESCRIPTION
## Problem

When running incremental sync on busy tables, the query will run for hours or days which causes issues on the database side, as it interferes with things like vacuuming.

## Proposed changes

To avoid making any sweeping changes on the incremental logic, I suggest introducing an optional `limit` config which would be added to every single incremental query to limit how many rows the query returns thus limit its runtime too.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [x] Description above provides context of the change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [x] CI checks pass with my changes
- [x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [x] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [x] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions
