### PR TITLE
Enabling the overriding of the catalog on the stream

### DIFF
--- a/tests/integration/test_streams_utils.py
+++ b/tests/integration/test_streams_utils.py
@@ -8,9 +8,9 @@ from tap_postgres.discovery_utils import BASE_RECURSIVE_SCHEMAS
 from tap_postgres import stream_utils
 
 try:
-	from tests.utils import get_test_connection, ensure_test_table, get_test_connection_config
+	from tests.utils import get_test_connection, ensure_test_table, get_test_connection_config, alter_schema_test_table
 except ImportError:
-	from utils import get_test_connection, ensure_test_table, get_test_connection_config
+	from utils import get_test_connection, ensure_test_table, get_test_connection_config, alter_schema_test_table
 
 
 def do_not_dump_catalog(catalog):
@@ -25,13 +25,17 @@ class TestInit(unittest.TestCase):
 	table_name = 'CHICKEN TIMES'
 
 	def setUp(self):
-		table_spec = {"columns": [{"name": "id", "type": "integer", "primary_key": True, "serial": True},
-								  {"name": '"character-varying_name"', "type": "character varying"},
-								  {"name": '"varchar-name"', "type": "varchar(28)"},
-								  {"name": 'char_name', "type": "char(10)"},
-								  {"name": '"text-name"', "type": "text"}],
-					  "name": self.table_name}
-
+		table_spec = {
+			"columns": [
+				{"name": "id", "type": "integer", "primary_key": True, "serial": True},
+				{"name": '"character-varying_name"', "type": "character varying"},
+				{"name": '"varchar-name"', "type": "varchar(28)"},
+				{"name": 'char_name', "type": "char(10)"},
+				{"name": '"text-name"', "type": "text"},
+				{"name": "nested_json", "type": "jsonb"},
+			],
+			"name": self.table_name
+		}		
 		ensure_test_table(table_spec)
 
 	def test_refresh_streams_schema(self):
@@ -42,7 +46,22 @@ class TestInit(unittest.TestCase):
 				'table_name': self.table_name,
 				'stream': self.table_name,
 				'tap_stream_id': f'public-{self.table_name}',
-				'schema': [],
+				'schema': {
+					'type': 'object',
+					'properties': {
+						'nested_json': {
+							'type': ['null', 'object'],
+							'properties': {
+								'name': {
+									'type': 'string'
+								},
+								'val': {
+									'type': 'string'
+								}
+							}
+						}
+					}
+				},
 				'metadata': [
 					{
 						'breadcrumb': [],
@@ -86,7 +105,10 @@ class TestInit(unittest.TestCase):
 										  'selected-by-default': True},
 			('properties', 'char_name'): {'selected-by-default': True,
 										  'inclusion': 'available',
-										  'sql-datatype': 'character'}})
+										  'sql-datatype': 'character'},
+			('properties', 'nested_json'): {'selected-by-default': True,
+										  'inclusion': 'available',
+										  'sql-datatype': 'jsonb'}})
 
 		self.assertEqual({'properties': {'id': {'type': ['integer'],
 												'maximum': 2147483647,
@@ -94,6 +116,112 @@ class TestInit(unittest.TestCase):
 										 'character-varying_name': {'type': ['null', 'string']},
 										 'varchar-name': {'type': ['null', 'string'], 'maxLength': 28},
 										 'char_name': {'type': ['null', 'string'], 'maxLength': 10},
-										 'text-name': {'type': ['null', 'string']}},
+										 'text-name': {'type': ['null', 'string']},
+										 'nested_json': {'type': ['null', 'object'],
+														 'properties': {
+															 		'name': {'type': 'string'},
+																	'val': {'type': 'string'},
+																}
+														}
+										},
+						  'type': 'object',
+						  'definitions': BASE_RECURSIVE_SCHEMAS}, streams[0].get('schema'))
+		
+	def alter_table(self):
+		table_spec = {
+			"columns": [
+				{"name": "char_name", "type": "integer"},
+				{"name": "text-name", "type": "integer", "changed_name": "text-name-altered"}
+			],
+			"name": self.table_name
+		}
+		alter_schema_test_table(table_spec)
+	
+	def test_refresh_streams_schema_aware_schema_evolution(self):
+		conn_config = get_test_connection_config()
+
+		streams = [
+			{
+				'table_name': self.table_name,
+				'stream': self.table_name,
+				'tap_stream_id': f'public-{self.table_name}',
+				'schema': {
+					'type': 'object',
+					'properties': {
+						'nested_json': {
+							'type': ['null', 'object'],
+							'properties': {
+								'name': {
+									'type': 'string'
+								},
+								'val': {
+									'type': 'string'
+								}
+							}
+						}
+					}
+				},
+				'metadata': [
+					{
+						'breadcrumb': [],
+						'metadata': {
+							'replication-method': 'LOG_BASED',
+							'table-key-properties': ['some_id'],
+							'row-count': 1000,
+						}
+					}
+				]
+			}
+		]
+
+		stream_utils.refresh_streams_schema(conn_config, streams)
+
+		self.assertEqual(len(streams), 1)
+		self.assertEqual(self.table_name, streams[0].get('table_name'))
+		self.assertEqual(self.table_name, streams[0].get('stream'))
+
+		streams[0]['metadata'].sort(key=lambda md: md['breadcrumb'])
+
+		self.assertEqual(metadata.to_map(streams[0]['metadata']), {
+			(): {'table-key-properties': ['id'],
+				 'database-name': 'postgres',
+				 'schema-name': 'public',
+				 'is-view': False,
+				 'row-count': 0,
+				 'replication-method': 'LOG_BASED'
+				 },
+			('properties', 'character-varying_name'): {'inclusion': 'available',
+													   'sql-datatype': 'character varying',
+													   'selected-by-default': True},
+			('properties', 'id'): {'inclusion': 'automatic',
+								   'sql-datatype': 'integer',
+								   'selected-by-default': True},
+			('properties', 'varchar-name'): {'inclusion': 'available',
+											 'sql-datatype': 'character varying',
+											 'selected-by-default': True},
+			('properties', 'text-name-altered'): {'inclusion': 'available',
+										  'sql-datatype': 'integer',
+										  'selected-by-default': True},
+			('properties', 'char_name'): {'selected-by-default': True,
+										  'inclusion': 'available',
+										  'sql-datatype': 'integer'},
+			('properties', 'nested_json'): {'selected-by-default': True,
+										  'inclusion': 'available',
+										  'sql-datatype': 'jsonb'}})
+
+		self.assertEqual({'properties': {'id': {'type': ['integer'],
+												'maximum': 2147483647,
+												'minimum': -2147483648},
+										 'character-varying_name': {'type': ['null', 'string']},
+										 'varchar-name': {'type': ['null', 'string'], 'maxLength': 28},
+										 'char_name': {'type': ['null', 'string'], 'maxLength': 10},
+										 'text-name-altered': {'type': ['null', 'integer']},
+										 'nested_json': {'type': ['null', 'object'],
+														 'properties': {
+															 		'name': {'type': 'string'},
+																	'val': {'type': 'string'},
+																}
+														}
+										},
 						  'type': 'object',
 						  'definitions': BASE_RECURSIVE_SCHEMAS}, streams[0].get('schema'))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -132,6 +132,23 @@ def ensure_test_table(table_spec, target_db='postgres'):
             LOGGER.info("create table sql: %s", sql)
             cur.execute(sql)
 
+def build_alter_table_sql(table, col_spec):
+    sqls = []
+    if altered_name:=col_spec.get('changed_name'):
+        sqls.append("ALTER TABLE {} RENAME COLUMN {} TO {}".format(table, col_spec['name'], altered_name))
+    if altered_type:=col_spec.get('type'):
+        sqls.append("ALTER TABLE {} ALTER COLUMN {} TYPE {}".format(table, col_spec['name'], altered_type))
+    return sqls
+    
+def alter_schema_test_table(table_spec, target_db='postgres'):
+    with get_test_connection(target_db) as conn:
+        with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as cur:
+            table = table_spec['name']
+            for col_spec in table_spec['columns']:
+                for sql in build_alter_table_sql(table, col_spec):
+                    LOGGER.info("alter table sql: %s", sql)
+                    cur.execute(sql)
+
 def unselect_column(our_stream, col):
     md = metadata.to_map(our_stream['metadata'])
     md.get(('properties', col))['selected'] = False


### PR DESCRIPTION

# Background

As described in the RFC above, flattening the schema is really needed. However, due to the limitation of the current tap, the stream does not contain the expected schemas for the downstream components to handle, thus the schema ends up not being flattened. This PR is to fix that. 

# Design

- Writing the merging process to override the schema from the catalog on the schema from the process of discovering db. 
- Writing the Unit Tests to test for our expected behaviors.

# Impact

This will help for the feature of flattening schema using `flattening_enabled` and `flattening_max_depth` from  the downstream components (like `mapper`) to be activated, thus realizing the schema flattening feature.

# Caveats

This PR does not cover one edge case in which the schema of the existing tables changes (like the column name is changed, the data type is changed,...) while the catalog is already created before. All those changes will not be synchronized onto the stream unless we delete the Catalog default file in `.run/meltano/tap-postgres`.
_(For the case adding a new column, this can work normally)_.

# Testing

There are 2 integration tests having been added. One is for testing the expected behavior of the stream merging mechanism and one is for testing the case described in the `Caveats`.

# Docs

None
